### PR TITLE
ci: migrate safe jobs to self-hosted runner + fix README badge owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     name: Ansible Lint
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
 
   syntax-check:
     name: Syntax Check
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
 
   terraform-validate:
     name: Terraform Validate
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Turing RK1 Ansible Cluster
 
-[![CI](https://github.com/jfreed-dev/turing-ansible-cluster/actions/workflows/ci.yml/badge.svg)](https://github.com/jfreed-dev/turing-ansible-cluster/actions/workflows/ci.yml)
+[![CI](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml/badge.svg)](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Infrastructure-as-code for deploying K3s Kubernetes on Turing Pi RK1 hardware with NPU support.
@@ -245,7 +245,7 @@ GitHub Actions runs on every push and PR:
 ## Related Repositories
 
 - [terraform-provider-turingpi](https://github.com/jfreed-dev/terraform-provider-turingpi) - Terraform BMC provider
-- [turing-rk1-cluster](https://github.com/jfreed-dev/turing-rk1-cluster) - Original Talos Linux cluster
+- [turing-rk1-cluster](https://github.com/freed-dev-llc/turing-rk1-cluster) - Original Talos Linux cluster
 
 ## License
 


### PR DESCRIPTION
## Summary
- Migrates 4 safe jobs from `ubuntu-latest` → `self-hosted` (Cerebrum runner).
- Keeps 3 jobs on cloud where they belong (Docker-daemon-dependent molecule, Linux-host armbian build, release).
- Fixes stale README badge URLs.

## Migrated
- `ci.yml` `lint` (Ansible Lint)
- `ci.yml` `syntax-check`
- `ci.yml` `terraform-validate`
- `dependabot-auto-merge.yml` `auto-merge`

## Kept on cloud
- `ci.yml` `molecule` — uses molecule-docker driver, needs full Docker daemon
- `armbian-build.yml` — sudo apt-get + maximize-build-space + QEMU (heavy Linux build)
- `release.yml` — softprops/action-gh-release + anchore/sbom-action

## Test plan
- [ ] CI runs green on this PR
- [ ] Molecule tests still run on ubuntu-latest (verify in Actions tab)