### PR TITLE
docs: fix README CI badge owner (jfreed-dev → freed-dev-llc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Turing RK1 Ansible Cluster
 
-[![CI](https://github.com/jfreed-dev/turing-ansible-cluster/actions/workflows/ci.yml/badge.svg)](https://github.com/jfreed-dev/turing-ansible-cluster/actions/workflows/ci.yml)
+[![CI](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml/badge.svg)](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Infrastructure-as-code for deploying K3s Kubernetes on Turing Pi RK1 hardware with NPU support.


### PR DESCRIPTION
Repo was transferred to freed-dev-llc; CI badge URL still pointed at the old jfreed-dev path. Captures the surviving relevant change from closed PR #2.