### PR TITLE
fix(armbian-build): pin Build Armbian job to ubuntu-latest

### DIFF
--- a/.github/workflows/armbian-build.yml
+++ b/.github/workflows/armbian-build.yml
@@ -53,7 +53,7 @@ jobs:
     name: Build Armbian
     needs: check-version
     if: needs.check-version.outputs.build_needed == 'true'
-    runs-on: [self-hosted, linux]
+    runs-on: ubuntu-latest
     timeout-minutes: 180
 
     steps:


### PR DESCRIPTION
easimon/maximize-build-space needs root + expects pre-installed packages from stock GitHub Ubuntu (dotnet/android/haskell/codeql). On Spark self-hosted runner it fails with 'swapoff: Not superuser'. This job is also heavy ARM emulation via QEMU — wrong fit for the small Spark fleet. Restoring to cloud (PR #2 had originally flagged this as a 'keep on cloud' exception).