### PR TITLE
fix(armbian-build): add no_check_bucket=true for bucket-scoped R2 token

### DIFF
--- a/.github/workflows/armbian-build.yml
+++ b/.github/workflows/armbian-build.yml
@@ -157,6 +157,7 @@ jobs:
           secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
           endpoint = ${{ secrets.R2_ENDPOINT }}
           region = auto
+          no_check_bucket = true
           EOF
           rclone listremotes
 


### PR DESCRIPTION
## Summary

One-line config change: add `no_check_bucket = true` to the rclone `[r2]` section.

## Why

The R2 token populating `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` is **bucket-scoped to `armbian-builds`** — it has Object Read & Write on that bucket but does NOT have account-wide `HeadBucket` permission. By default rclone runs a preflight bucket existence check on every `copy` invocation, which returns 403 AccessDenied for this token and aborts the upload before any object is touched.

Past two Build Armbian runs (26041573168, 26042709817) hit this. Verified the same creds work for an actual PUT — confirmed locally a 1-byte upload succeeds with `no_check_bucket = true` set and fails without it.

## Test plan

- [ ] Re-trigger workflow after merge; Upload to Cloudflare R2 step should now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)