### PR TITLE
chore(actions): bump Node20-deprecated actions ahead of 2026-06-02 forced upgrade

### DIFF
--- a/.github/workflows/armbian-build.yml
+++ b/.github/workflows/armbian-build.yml
@@ -23,7 +23,7 @@ jobs:
       upstream_version: ${{ steps.check.outputs.upstream_version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check upstream VERSION
         id: check
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: [self-hosted, linux]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -43,10 +43,10 @@ jobs:
     runs-on: [self-hosted, linux]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -78,10 +78,10 @@ jobs:
     runs-on: [self-hosted, linux]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.5'
 
@@ -107,10 +107,10 @@ jobs:
           - k3s_server
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Auto-approve patch and minor updates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Bumps all action pins still on a Node20-only major to their Node24-supporting successors, ahead of the 2026-06-02 forced-Node24 cutover.
- Per-action upgrades:
  - `actions/checkout` `v4` → `v6`
  - `actions/setup-python` `v5` → `v6`
  - `hashicorp/setup-terraform` `v3` → `v4`
  - `dependabot/fetch-metadata` `v2` → `v3` (only in `dependabot-auto-merge.yml`)

## Why
The CI run `26044779579` on `main` 2026-05-18 emitted the deprecation warning for `actions/checkout@v4` and `actions/setup-python@v5` explicitly. The other two haven't warned yet but are also Node20-era and will at some point. Floating-major refs preserved to match this repo's existing unpinned convention.

## Test plan
- [ ] CI (Ansible Lint + Syntax Check + Molecule (base) + Molecule (k3s_server) + Terraform Validate) stays green on this PR
- [ ] Armbian Build workflow can still be force-triggered (light smoke, optional — it's slow)
- [ ] Release workflow remains valid (no run triggered until next tag)
- [ ] Dependabot auto-merge workflow remains valid (no run triggered until next dependabot PR)
- [ ] No new Node20-deprecation warnings in the CI logs