### PR TITLE
docs: address license, org, K3s, and architecture drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,24 +329,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive installation guide (INSTALL.md)
 - Implementation documentation (docs/IMPLEMENTATION.md)
 
-[1.3.6]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.3.5...v1.3.6
-[1.3.5]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.3.4...v1.3.5
-[1.3.4]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.3.3...v1.3.4
-[1.3.3]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.3.2...v1.3.3
-[1.3.2]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.3.1...v1.3.2
-[1.3.1]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.2.1...v1.3.0
-[1.2.1]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.2.0...v1.2.1
-[1.2.0]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.1.9...v1.2.0
-[1.1.9]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.1.8...v1.1.9
-[1.1.8]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.1.7...v1.1.8
-[1.1.7]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.1.6...v1.1.7
-[1.1.6]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.1.5...v1.1.6
-[1.1.5]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.1.4...v1.1.5
-[1.1.4]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.1.3...v1.1.4
-[1.1.3]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.1.2...v1.1.3
-[1.1.2]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.1.1...v1.1.2
-[1.1.1]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/jfreed-dev/turing-ansible-cluster/compare/v0.1.0...v1.0.0
-[0.1.0]: https://github.com/jfreed-dev/turing-ansible-cluster/releases/tag/v0.1.0
+[1.3.6]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.3.5...v1.3.6
+[1.3.5]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.3.4...v1.3.5
+[1.3.4]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.3.3...v1.3.4
+[1.3.3]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.3.2...v1.3.3
+[1.3.2]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.2.1...v1.3.0
+[1.2.1]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.1.9...v1.2.0
+[1.1.9]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.1.8...v1.1.9
+[1.1.8]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.1.7...v1.1.8
+[1.1.7]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.1.6...v1.1.7
+[1.1.6]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.1.5...v1.1.6
+[1.1.5]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.1.4...v1.1.5
+[1.1.4]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.1.3...v1.1.4
+[1.1.3]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.1.2...v1.1.3
+[1.1.2]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/freed-dev-llc/turing-ansible-cluster/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/freed-dev-llc/turing-ansible-cluster/releases/tag/v0.1.0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -627,7 +627,7 @@ ansible-playbook -i inventories/server/hosts.yml playbooks/site.yml
 ssh root@10.10.88.73
 
 # Install K3s server
-curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.31.3+k3s1" sh -s - server \
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.31.4+k3s1" sh -s - server \
   --cluster-cidr=10.244.0.0/16 \
   --service-cidr=10.96.0.0/12 \
   --disable=traefik \
@@ -644,7 +644,7 @@ cat /var/lib/rancher/k3s/server/node-token
 ssh root@10.10.88.74  # Repeat for .75, .76
 
 # Install K3s agent
-curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.31.3+k3s1" \
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.31.4+k3s1" \
   K3S_URL="https://10.10.88.73:6443" \
   K3S_TOKEN="<token from control plane>" \
   sh -s - agent
@@ -658,10 +658,10 @@ kubectl get nodes -o wide
 
 # Expected:
 # NAME         STATUS   ROLES                  AGE   VERSION
-# node1   Ready    control-plane,master   5m    v1.31.3+k3s1
-# node2    Ready    <none>                 3m    v1.31.3+k3s1
-# node3    Ready    <none>                 3m    v1.31.3+k3s1
-# node4    Ready    <none>                 3m    v1.31.3+k3s1
+# node1   Ready    control-plane,master   5m    v1.31.4+k3s1
+# node2    Ready    <none>                 3m    v1.31.4+k3s1
+# node3    Ready    <none>                 3m    v1.31.4+k3s1
+# node4    Ready    <none>                 3m    v1.31.4+k3s1
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Turing RK1 Ansible Cluster
 
 [![CI](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml/badge.svg)](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Infrastructure-as-code for deploying K3s Kubernetes on Turing Pi RK1 hardware with NPU support.
 
@@ -11,7 +11,7 @@ Infrastructure-as-code for deploying K3s Kubernetes on Turing Pi RK1 hardware wi
 
 Deploy a 4-node K3s cluster on Turing Pi with:
 - **Armbian** with Rockchip BSP kernel (NPU support)
-- **Terraform** for BMC flashing via [terraform-provider-turingpi](https://github.com/jfreed-dev/terraform-provider-turingpi)
+- **Terraform** for BMC flashing via [terraform-provider-turingpi](https://github.com/freed-dev-llc/terraform-provider-turingpi)
 - **Ansible** for K3s installation and addon deployment
 - **Networking** matching existing Talos cluster configuration
 
@@ -244,9 +244,9 @@ GitHub Actions runs on every push and PR:
 
 ## Related Repositories
 
-- [terraform-provider-turingpi](https://github.com/jfreed-dev/terraform-provider-turingpi) - Terraform BMC provider
-- [turing-rk1-cluster](https://github.com/jfreed-dev/turing-rk1-cluster) - Original Talos Linux cluster
+- [terraform-provider-turingpi](https://github.com/freed-dev-llc/terraform-provider-turingpi) - Terraform BMC provider
+- [turing-rk1-cluster](https://github.com/freed-dev-llc/turing-rk1-cluster) - Original Talos Linux cluster
 
 ## License
 
-MIT
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,7 @@ graph TB
     end
 
     subgraph "Kubernetes Cluster"
-        K3S[K3s v1.31.3]
+        K3S[K3s v1.31.4]
         Flannel[Flannel CNI<br/>10.244.0.0/16]
         MetalLB[MetalLB<br/>10.10.88.80-89]
         Longhorn[Longhorn Storage]
@@ -284,8 +284,9 @@ graph TB
 %%{init: {'theme': 'neutral'}}%%
 graph TB
     subgraph "Node 1 (Control Plane)"
-        N1_eMMC[eMMC 64GB<br/>System Only]
-        N1_Boot[Armbian Boot]
+        N1_eMMC[eMMC 64GB<br/>System]
+        N1_NVMe[NVMe 512GB<br/>Data]
+        N1_Longhorn[Longhorn Volume]
     end
 
     subgraph "Node 2 (Worker)"
@@ -317,7 +318,8 @@ graph TB
         SC[StorageClass: longhorn]
     end
 
-    N1_eMMC --> N1_Boot
+    N1_eMMC --> N1_NVMe
+    N1_NVMe --> N1_Longhorn
 
     N2_eMMC --> N2_NVMe
     N2_NVMe --> N2_Longhorn
@@ -328,6 +330,7 @@ graph TB
     N4_eMMC --> N4_NVMe
     N4_NVMe --> N4_Longhorn
 
+    N1_Longhorn --> Manager
     N2_Longhorn --> Manager
     N3_Longhorn --> Manager
     N4_Longhorn --> Manager
@@ -343,7 +346,7 @@ graph TB
 
 | Node | eMMC | NVMe | Longhorn Mount |
 |------|------|------|----------------|
-| Node 1 | 64GB (System) | - | - |
+| Node 1 | 64GB (System) | 512GB | /var/lib/longhorn |
 | Node 2 | 64GB (System) | 512GB | /var/lib/longhorn |
 | Node 3 | 64GB (System) | 512GB | /var/lib/longhorn |
 | Node 4 | 64GB (System) | 512GB | /var/lib/longhorn |
@@ -384,7 +387,6 @@ graph TB
         Prometheus[Prometheus]
         Grafana[Grafana]
         Alertmanager[Alertmanager]
-        NodeExporter[Node Exporter]
     end
 
     subgraph "portainer"
@@ -408,7 +410,6 @@ graph TB
     LHManager --> LHEngine
     LHManager --> LHDriver
 
-    Prometheus --> NodeExporter
     Prometheus --> Grafana
     Prometheus --> Alertmanager
 ```
@@ -472,8 +473,6 @@ graph TB
 graph TB
     subgraph "Inventory Targets"
         Server[inventories/server/<br/>Turing Pi RK1]
-        VM[inventories/vm/<br/>Virtual Machines]
-        Laptop[inventories/laptop/<br/>PopOS Workstation]
     end
 
     subgraph "Server Inventory"
@@ -531,14 +530,13 @@ turing-ansible-cluster/
 │   │   ├── portainer/        # Management UI
 │   │   └── rknn/             # NPU runtime
 │   ├── inventories/
-│   │   ├── server/           # Production cluster
-│   │   ├── vm/               # Test VMs
-│   │   └── laptop/           # Workstation
+│   │   └── server/           # Production cluster
 │   └── files/helm-values/    # Helm chart values
 └── docs/
     ├── ARCHITECTURE.md       # This file
     ├── IMPLEMENTATION.md     # Deployment procedures
-    ├── NETWORKING.md         # Network configuration
-    ├── STORAGE.md            # Storage setup
-    └── MONITORING.md         # Observability
+    ├── ARMBIAN-BUILD.md      # Armbian image build pipeline
+    ├── NPU-API.md            # NPU runtime + API
+    ├── NVME-MIGRATION.md     # NVMe migration plan
+    └── VAULT-SETUP.md        # Ansible Vault notes
 ```

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -52,13 +52,21 @@ done
 
 ### 0.4 Firmware Image Download
 
+Use the latest Armbian image published by this repo's nightly build to the R2
+bucket (see `docs/ARMBIAN-BUILD.md`). Read the version from the unified
+manifest so the URL doesn't go stale:
+
 ```bash
-# Download Ubuntu 22.04 for RK1 from Turing Pi
-wget -O ~/Downloads/ubuntu-22.04-rk1.img.xz \
-  https://firmware.turingpi.com/turing-rk1/ubuntu/ubuntu-22.04-server.img.xz
+# Resolve the latest Armbian download URL from the manifest
+URL=$(curl -sf https://armbian-builds.techki.to/turing-rk1/images.json \
+        | jq -r '.armbian.latest.download_url')
+echo "$URL"
+
+# Download
+wget -O ~/Downloads/armbian-turing-rk1.img.xz "$URL"
 
 # Extract (optional - Terraform can handle .xz)
-xz -dk ~/Downloads/ubuntu-22.04-rk1.img.xz
+xz -dk ~/Downloads/armbian-turing-rk1.img.xz
 ```
 
 ---
@@ -87,12 +95,12 @@ terraform init
 # Plan the flash operation
 terraform plan \
   -var="flash_nodes=true" \
-  -var="firmware_path=$HOME/Downloads/ubuntu-22.04-rk1.img"
+  -var="firmware_path=$HOME/Downloads/armbian-turing-rk1.img"
 
 # Execute flash (WARNING: destructive, ~30-60 min per node)
 terraform apply \
   -var="flash_nodes=true" \
-  -var="firmware_path=$HOME/Downloads/ubuntu-22.04-rk1.img"
+  -var="firmware_path=$HOME/Downloads/armbian-turing-rk1.img"
 ```
 
 ### 1.3 Verify Boot
@@ -162,7 +170,7 @@ ansible-playbook -i inventories/server/hosts.yml playbooks/kubernetes.yml
 **Execution Order:**
 
 1. **Control Plane (node1)** - serial execution
-   - Install K3s server v1.31.3+k3s1
+   - Install K3s server v1.31.4+k3s1
    - Configure: Pod CIDR 10.244.0.0/16, Service CIDR 10.96.0.0/12
    - Disable traefik and servicelb (using MetalLB + NGINX instead)
    - Generate cluster token
@@ -335,102 +343,6 @@ kubectl get pvc test-pvc
 # Cleanup
 kubectl delete pvc test-pvc
 ```
-
----
-
-## Phase 7: VM Cluster Deployment (Pop!_OS)
-
-### 7.1 Create VMs
-
-Create 3 Pop!_OS VMs with the following specifications:
-
-| VM | Hostname | IP | vCPU | RAM | Disk |
-|----|----------|-----|------|-----|------|
-| vm-cp1 | popos-k3s-cp1 | 192.168.122.10 | 4 | 8GB | 50GB |
-| vm-w1 | popos-k3s-w1 | 192.168.122.11 | 4 | 8GB | 50GB |
-| vm-w2 | popos-k3s-w2 | 192.168.122.12 | 4 | 8GB | 50GB |
-
-**Pop!_OS Installation Settings:**
-
-- Use Pop!_OS 24.04 LTS ISO
-- No drive encryption
-- Create initial user (any name - will be reconfigured)
-- Set static IPs per table above
-
-### 7.2 Provision VMs
-
-```bash
-cd ~/Code/turing-ansible-cluster/ansible
-
-# First run - use password authentication
-ansible-playbook -i inventories/vm/hosts.yml playbooks/vm-provision.yml -k --ask-become-pass
-```
-
-**Actions Performed:**
-
-- Creates user `jon` with admin privileges
-- Sets random passwords for `root` and `jon`
-- Displays passwords and saves to `credentials/vm-credentials.txt`
-- Sets hostnames per Pop!_OS best practices
-- Installs KVM guest drivers (qemu-guest-agent, spice-vdagent)
-- Configures SSH keys for passwordless access
-- Disables swap for Kubernetes
-- Enables automatic security updates
-
-### 7.3 Deploy K3s to VMs
-
-```bash
-# Bootstrap (now passwordless SSH works)
-ansible-playbook -i inventories/vm/hosts.yml playbooks/bootstrap.yml
-
-# Full cluster deployment
-ansible-playbook -i inventories/vm/hosts.yml playbooks/site.yml
-```
-
-### 7.4 Access VM Cluster
-
-```bash
-export KUBECONFIG=~/Code/turing-ansible-cluster/ansible/kubeconfig
-
-# Add to /etc/hosts
-echo "192.168.122.80  grafana.vm.local prometheus.vm.local longhorn.vm.local" | sudo tee -a /etc/hosts
-
-kubectl get nodes
-```
-
-**Credentials Location:** `ansible/credentials/vm-credentials.txt` (git-ignored)
-
----
-
-## Phase 8: Laptop/Workstation Setup
-
-### 8.1 Deploy Workstation Playbook
-
-```bash
-cd ~/Code/turing-ansible-cluster/ansible
-
-ansible-playbook -i inventories/laptop/hosts.yml playbooks/workstation.yml
-```
-
-**Installed Components:**
-
-- Development packages (git, curl, vim, htop, tmux, jq)
-- Docker CE
-- kubectl
-- Helm
-- Dotfiles from laptop-configs-popos (optional)
-
-### 8.2 Optional: Join Laptop to Cluster
-
-Edit `inventories/laptop/hosts.yml`:
-
-```yaml
-join_cluster: true
-k3s_server_url: "https://10.10.88.73:6443"
-k3s_token: "<token from control plane>"
-```
-
-Then re-run playbook.
 
 ---
 


### PR DESCRIPTION
## Summary

Findings from the 2026-05-19 multi-pass audit (and verification against ground truth — `metallb-config.yaml`, `inventories/server/hosts.yml`, and the unified `images.json`).

### License — repo is Apache 2.0, doc said MIT
- README badge + License footer corrected.

### Org migration `jfreed-dev` → `freed-dev-llc`
- README "Related Repositories" + Overview provider link.
- CHANGELOG.md: 21 `[X.Y.Z]` compare-link footers bulk-updated via `sed`.

### K3s version — inventory pins `v1.31.4+k3s1`
- INSTALL.md (6 occurrences), docs/IMPLEMENTATION.md, docs/ARCHITECTURE.md diagram label all bumped from v1.31.3 → v1.31.4.

### ARCHITECTURE.md storage diagram — Node 1 has NVMe
- Inventory has `has_nvme: true` for all 4 nodes since v1.1.4. Storage subgraph + Storage Configuration table updated to match; CP no longer drawn as eMMC-only.

### ARCHITECTURE.md "Monitoring Stack" — Node Exporter is disabled
- Removed the `NodeExporter` block and the `Prometheus --> NodeExporter` edge (disabled in commit 9ef10f6).

### ARCHITECTURE.md "Inventory Targets" + File Structure
- Removed `inventories/vm/` and `inventories/laptop/` from the diagram (only `inventories/server/` exists).
- docs/ tree: dropped nonexistent NETWORKING/STORAGE/MONITORING.md; added the docs that *do* exist (ARMBIAN-BUILD, NPU-API, NVME-MIGRATION, VAULT-SETUP).

### IMPLEMENTATION.md — Phases 7 & 8 covered paths that don't exist
- Deleted Phase 7 (VM Cluster Deployment) and Phase 8 (Laptop/Workstation Setup). Both referenced playbooks (`vm-provision.yml`, `workstation.yml`) and inventories (`inventories/vm/`, `inventories/laptop/`) that have never existed.
- Phase 0.4 firmware download: switched from a stale Ubuntu 22.04 URL to the Armbian image published nightly to the R2 bucket — resolved dynamically from `images.json` so the URL doesn't bit-rot.

### What I *didn't* fix (auditor false positives)
- **Armbian 26.02.0-trunk in 9 places** — the auditor claimed current was 26.05.0-trunk. Ground truth (`https://armbian-builds.techki.to/turing-rk1/images.json | jq .armbian.latest`) is still 26.02.0-trunk (build_date 2025-12-26). The nightly workflow ran successfully but didn't publish a new version because upstream Armbian hasn't moved.
- **Portainer "10.10.81.81 vs 10.10.88.81" conflict** — these are two different things: `portainer_server: 10.10.81.81` is the external server URL, `portainer_lb_ip: 10.10.88.81` is the K8s service LB IP. Both correct.

## Test plan
- [ ] CI green