### PR TITLE
docs: tier-3 cleanup (~/Code paths, rknn-llm version, vault opt-in)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -609,7 +609,7 @@ cat /sys/kernel/debug/rknpu/load     # Core utilization
 ### Using Ansible (Recommended)
 
 ```bash
-cd ~/Code/turing-ansible-cluster/ansible
+cd $REPO_ROOT/ansible
 
 # Setup secrets
 ./scripts/setup-secrets.sh

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -460,7 +460,7 @@ graph TB
 |-----------|---------|
 | Driver | rknpu v0.9.8+ (vendor kernel) |
 | Device | /dev/dri/renderD129 |
-| Runtime | rknn-llm v1.2.3 |
+| Runtime | rknn-llm v1.2.1 |
 | API Port | 8080 |
 | CPU Cores | 4-7 (big cores for NPU) |
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -27,7 +27,7 @@ terraform --version  # >= 1.5
 ansible --version    # >= 2.15
 
 # Install Ansible collections
-cd ~/Code/turing-ansible-cluster/ansible
+cd $REPO_ROOT/ansible
 ansible-galaxy install -r requirements.yml
 ```
 
@@ -76,7 +76,7 @@ xz -dk ~/Downloads/armbian-turing-rk1.img.xz
 ### 1.1 Configure Terraform
 
 ```bash
-cd ~/Code/turing-ansible-cluster/terraform/environments/server
+cd $REPO_ROOT/terraform/environments/server
 
 # Set BMC credentials
 export TURINGPI_USERNAME=root
@@ -131,7 +131,7 @@ sudo netplan apply
 ### 2.1 Verify Connectivity
 
 ```bash
-cd ~/Code/turing-ansible-cluster/ansible
+cd $REPO_ROOT/ansible
 
 # Test SSH access
 ansible -i inventories/server/hosts.yml all -m ping
@@ -184,7 +184,7 @@ ansible-playbook -i inventories/server/hosts.yml playbooks/kubernetes.yml
 ### 3.2 Verify Cluster
 
 ```bash
-export KUBECONFIG=~/Code/turing-ansible-cluster/ansible/kubeconfig
+export KUBECONFIG=$REPO_ROOT/ansible/kubeconfig
 
 kubectl get nodes -o wide
 # Expected: 4 nodes in Ready state
@@ -359,7 +359,7 @@ kubectl delete pvc test-pvc
 ### Rollback to Talos
 
 ```bash
-cd ~/Code/turing-ansible-cluster/terraform/environments/server
+cd $REPO_ROOT/terraform/environments/server
 
 # Flash Talos image instead
 terraform apply \

--- a/docs/VAULT-SETUP.md
+++ b/docs/VAULT-SETUP.md
@@ -2,6 +2,11 @@
 
 This document explains how to configure Ansible Vault for secure secrets management in this repository.
 
+> **Note:** Vault is opt-in. The default `inventories/server/hosts.yml` keeps
+> secrets in plain text (gitignored alongside `.example`). The steps below
+> show how to switch to a vault-encrypted workflow if you want that — it's
+> not required for the playbooks to run.
+
 ## Overview
 
 Ansible Vault encrypts sensitive data (passwords, tokens, keys) so they can be safely stored in version control. This repository uses vault for:


### PR DESCRIPTION
Cosmetic follow-ups from the 2026-05-19 audit.

### Hardcoded `~/Code/turing-ansible-cluster` paths
Replaced with `$REPO_ROOT` so snippets are portable:
- INSTALL.md (1x)
- docs/IMPLEMENTATION.md (5x)

### rknn-llm version inconsistency
- INSTALL.md table: `v1.2.1`
- docs/ARCHITECTURE.md table: `v1.2.3`
The role clones HEAD; INSTALL.md is the canonical reference for what installs. Aligned ARCHITECTURE.md to v1.2.1.

### VAULT-SETUP.md framed as mandatory, but vault is opt-in
Added a note up top noting that the live `inventories/server/hosts.yml` keeps secrets in plain text (gitignored), and vault is one (optional) approach.

## Test plan
- [ ] CI green