### PR TITLE
ci(dependabot): approve/merge via DEPENDABOT_AUTOMERGE_TOKEN

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,10 +21,10 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
       - name: Auto-merge patch and minor updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
## Why
GitHub Actions cannot approve PRs (`addPullRequestReview` is blocked), so the self-approve step in this workflow fails every run and Dependabot PRs cannot auto-merge.

## Change
Route the approve + merge `gh` calls through `secrets.DEPENDABOT_AUTOMERGE_TOKEN` — a fine-grained PAT owned by `jfreed-dev` (the CODEOWNER), so the approval satisfies branch protection. Other token usages are unchanged.

Part of the org-wide fix (modules: #61). Requires org secret `DEPENDABOT_AUTOMERGE_TOKEN` (Pull requests: RW, Contents: RW).
