### PR TITLE
ci(dependabot): use org reusable auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,10 @@
 name: Dependabot Auto-Merge
 
+# Thin caller for the org reusable workflow in freed-dev-llc/.github.
+# Single source of truth lives there; this file should not diverge.
+# Requires the DEPENDABOT_AUTOMERGE_TOKEN *Dependabot* org secret to be
+# scoped to this repo.
+
 on: pull_request
 
 permissions:
@@ -8,23 +13,7 @@ permissions:
 
 jobs:
   auto-merge:
-    runs-on: [self-hosted, linux]
-    if: github.actor == 'dependabot[bot]'
-    steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Auto-approve patch and minor updates
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
-      - name: Auto-merge patch and minor updates
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    uses: freed-dev-llc/.github/.github/workflows/dependabot-auto-merge.yml@main
+    secrets:
+      DEPENDABOT_AUTOMERGE_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
## Change
Replace the inline Dependabot auto-merge workflow with a thin caller of the org reusable workflow (`freed-dev-llc/.github/.github/workflows/dependabot-auto-merge.yml@main`) — single source of truth, no per-repo drift.

Functionally identical (approve+merge non-major Dependabot PRs via the `DEPENDABOT_AUTOMERGE_TOKEN` Dependabot secret); just centralized.
