### PR TITLE
docs: fix stale version refs, addon order, and NPU/vault details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `ansible/inventories/server/hosts.yml.example` k3s_version bumped from v1.31.3 to v1.31.4+k3s1 (pass-5 missed this template file; live `hosts.yml` was already on v1.31.4).
+- Armbian image metadata bumped to `26.08.0-trunk` (build 2026-06-06, kernel 6.1.115) in `images.json` (`eb1d3f0`).
 
 ### Removed
 
@@ -59,29 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Compatibility
 
 The K3s version bump (v1.31.3 → v1.31.4+k3s1) is a patch-level upgrade and is non-breaking. The role-level default change matches what the live inventory has been overriding to since `be9d9a6`; no operator action required. The Apache 2.0 relicense (from MIT) is intentionally permissive — no action required for consumers.
-- **Org migration: `jfreed-dev` → `freed-dev-llc`.** Repo was silently transferred; this release fixes all surviving `jfreed-dev` references in README + 21 CHANGELOG compare-links + docs (#9). GitHub URL redirects still work but the canonical org is now `freed-dev-llc`.
-- **K3s version: v1.31.3 → v1.31.4+k3s1** across inventory, docs, and the `k3s_server` role's default + Molecule tests (#9, this release).
-- **Ansible role `k3s_server`** default `k3s_version` bumped to match live cluster (was lagging by one patch).
-- Architecture docs (`docs/ARCHITECTURE.md`) — storage diagram redrawn with NVMe on all 4 nodes (matches inventory `has_nvme: true` since v1.1.4); `Node Exporter` removed from monitoring stack (disabled in `9ef10f6`); `inventories/vm/` + `inventories/laptop/` references removed (those inventories never existed) (#9).
-- Implementation guide (`docs/IMPLEMENTATION.md`) — deleted Phase 7 (VM Cluster Deployment) and Phase 8 (Laptop/Workstation Setup); both referenced playbooks (`vm-provision.yml`, `workstation.yml`) and inventories that don't exist in this repo (#9, this release). Phase 0.4 firmware download switched from a stale Ubuntu 22.04 URL to the Armbian image published nightly to R2 — resolved dynamically from `images.json` (#9). Target Environments table trimmed to just Server; summary table dropped Phase 7/8 and the orphan "Total (VM)" row.
-- Hardcoded `~/Code/turing-ansible-cluster` paths in INSTALL.md + IMPLEMENTATION.md replaced with `$REPO_ROOT` (#10).
-- Hardcoded `~/Code/turing-rk1-cluster` (sibling repo) path in IMPLEMENTATION.md updated to `~/Repos/turing-rk1-cluster` (this release).
-- `docs/ARCHITECTURE.md` `rknn-llm` runtime label corrected from v1.2.3 → v1.2.1 to match INSTALL.md (the role clones HEAD, INSTALL.md is canonical) (#10).
-- `docs/VAULT-SETUP.md` clarified that vault is opt-in — the default inventory keeps secrets in plain text (gitignored) (#10).
-- Mermaid diagrams in `docs/ARCHITECTURE.md` locked to the `neutral` theme for cross-mode legibility (#8).
-
-### Added
-
-- `CODE_OF_CONDUCT.md` (Contributor Covenant, copied from sister repo) (#11).
-- `.editorconfig` for cross-editor formatting consistency (#11).
-
-### Fixed
-
-- Node20-deprecated GitHub Actions bumped ahead of the 2026-06-02 forced upgrade (#7).
-
-### Compatibility
-
-The K3s version bump (v1.31.3 → v1.31.4+k3s1) is a patch-level upgrade and is non-breaking. The role-level default change matches what the live inventory has been overriding to since `be9d9a6`; no operator action required.
 
 ## [1.3.6] - 2025-12-27
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -182,7 +182,7 @@ cd ~/armbian-build
 ### Build Output
 
 ```
-~/armbian-build/output/images/Armbian-unofficial_26.02.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img
+~/armbian-build/output/images/Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img
 ```
 
 Build time: ~5-10 minutes (uses Docker, downloads cached packages)
@@ -200,7 +200,7 @@ export TPI_USERNAME=root
 export TPI_PASSWORD="your_bmc_password"
 
 # Flash node 1
-tpi flash --node 1 --image-path ~/Downloads/Armbian-unofficial_26.02.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img
+tpi flash --node 1 --image-path ~/Downloads/Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img
 
 # Power on after flash
 tpi power on --node 1
@@ -242,7 +242,7 @@ Reference: [Armbian Autoconfig Documentation](https://docs.armbian.com/User-Guid
 ```bash
 # Prepare image for node 1 with static IP
 sudo ./scripts/prepare-armbian-image.sh \
-  ~/Downloads/Armbian-unofficial_26.02.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img \
+  ~/Downloads/Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img \
   1
 
 # Or with custom settings
@@ -277,10 +277,10 @@ tpi power on
    - `PRESET_USER_SHELL` - Selects bash
    - `PRESET_NET_*` - Static IP configuration (if node specified)
    - `PRESET_LOCALE` / `PRESET_TIMEZONE` - System locale
-3. Creates `/root/provisioning.sh` for post-boot setup:
-   - Adds SSH authorized keys
-   - Sets hostname
-   - Configures /etc/hosts with cluster nodes
+3. Writes configuration directly into the mounted image:
+   - SSH authorized keys to `/root/.ssh/authorized_keys`
+   - Hostname to `/etc/hostname`
+   - Cluster node entries in `/etc/hosts`
 4. Unmounts the image
 
 ### Manual Autoconfig (Without Script)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Deploy a 4-node K3s cluster on Turing Pi with:
 - Terraform >= 1.5
 - Ansible >= 2.15
 - Turing Pi BMC access
-- Armbian image (see [Building Armbian](#building-armbian) or [download pre-built](https://armbian-builds.techki.to/turing-rk1/26.02.0-trunk/Armbian-unofficial_26.02.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz))
+- Armbian image (see [Building Armbian](#building-armbian) or [download pre-built](https://armbian-builds.techki.to/turing-rk1/armbian/26.08.0-trunk/Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz))
 
 ## Quick Start
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -204,8 +204,8 @@ sequenceDiagram
         Op->>Ansible: ansible-playbook addons.yml
         Ansible->>Nodes: Deploy MetalLB
         Ansible->>Nodes: Deploy NGINX Ingress
-        Ansible->>Nodes: Deploy Longhorn
         Ansible->>Nodes: Deploy Prometheus Stack
+        Ansible->>Nodes: Deploy Longhorn
         Ansible->>Nodes: Deploy Portainer Agent
     end
 ```
@@ -396,8 +396,8 @@ graph TB
     subgraph "Addon Dependencies"
         direction LR
         D1[MetalLB] --> D2[NGINX Ingress]
-        D2 --> D3[Longhorn]
-        D3 --> D4[Prometheus Stack]
+        D2 --> D3[Prometheus Stack]
+        D3 --> D4[Longhorn]
         D4 --> D5[Portainer]
     end
 

--- a/docs/ARMBIAN-BUILD.md
+++ b/docs/ARMBIAN-BUILD.md
@@ -15,7 +15,7 @@ Pre-built images are automatically generated when new Armbian versions are relea
 
 | Property | Value |
 |----------|-------|
-| Version | 26.02.0-trunk |
+| Version | 26.08.0-trunk |
 | Kernel | 6.1.115 (vendor branch, NPU support) |
 | Release | Bookworm (Debian 12) |
 | Size | ~491 MB (compressed) |
@@ -388,7 +388,7 @@ dmesg | grep -i rknpu
 
 If you don't need customization, download pre-built images:
 
-- **Pre-built (Recommended)**: [armbian-builds.techki.to](https://armbian-builds.techki.to/turing-rk1/armbian/26.02.0-trunk/Armbian-unofficial_26.02.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz) - vendor kernel with NPU support
+- **Pre-built (Recommended)**: [armbian-builds.techki.to](https://armbian-builds.techki.to/turing-rk1/armbian/26.08.0-trunk/Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz) - vendor kernel with NPU support
 - **Turing Pi Ubuntu**: https://firmware.turingpi.com/turing-rk1/
 
 > **Note**: The pre-built images from armbian-builds.techki.to include the `vendor` branch kernel required for NPU support.
@@ -472,11 +472,11 @@ TIMEZONE="UTC" ./scripts/prepare-armbian-image.sh Armbian.img 4
 
 ```bash
 # Decompress image once
-xz -dk Armbian-unofficial_26.02.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz
+xz -dk Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz
 
 # Create copies for each node
 for n in 1 2 3 4; do
-  cp Armbian-unofficial_26.02.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img node${n}.img
+  cp Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img node${n}.img
   ./scripts/prepare-armbian-image.sh node${n}.img $n
 done
 
@@ -524,7 +524,7 @@ Pre-built Armbian images are hosted on Cloudflare R2 at [armbian-builds.techki.t
 ./scripts/download-armbian-image.sh --latest
 
 # Or download directly
-wget https://armbian-builds.techki.to/turing-rk1/armbian/26.02.0-trunk/Armbian-unofficial_26.02.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz
+wget https://armbian-builds.techki.to/turing-rk1/armbian/26.08.0-trunk/Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz
 
 # Download and auto-decompress
 DECOMPRESS=true ./scripts/download-armbian-image.sh --latest

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -44,7 +44,7 @@ for ip in 10.10.88.{73..76}; do ping -c 1 $ip; done
 ```bash
 # Copy SSH key to nodes (after OS flash)
 for ip in 10.10.88.{73..76}; do
-  ssh-copy-id ubuntu@$ip
+  ssh-copy-id root@$ip
 done
 ```
 
@@ -106,7 +106,7 @@ terraform apply \
 ```bash
 # Terraform waits for boot_pattern="login:" on UART
 # Manual verification:
-ssh ubuntu@10.10.88.73  # Default password may be "ubuntu"
+ssh root@10.10.88.73
 ```
 
 ### 1.4 Post-Flash: Set Static IPs
@@ -144,8 +144,8 @@ ansible-playbook -i inventories/server/hosts.yml playbooks/bootstrap.yml
 **Actions Performed:**
 
 - Update apt cache
-- Install base packages (curl, wget, git, htop, btop, vim, tmux, jq, open-iscsi, nfs-common)
-- Load kernel modules (iscsi_tcp, dm_crypt)
+- Install base packages (curl, wget, git, htop, btop, vim, tmux, jq, yq, unzip, python3-pip, open-iscsi, nfs-common, cryptsetup)
+- Load kernel modules (br_netfilter, overlay, iscsi_tcp)
 - Apply sysctl settings for Kubernetes networking
 - Set hostnames (node1, node2, node3, node4)
 - Configure /etc/hosts with cluster nodes
@@ -209,8 +209,8 @@ ansible-playbook -i inventories/server/hosts.yml playbooks/addons.yml
 |-------|-------|-----------|---------|
 | 1 | MetalLB | metallb-system | L2 LoadBalancer (10.10.88.80-89) |
 | 2 | NGINX Ingress | ingress-nginx | Ingress controller at 10.10.88.80 |
-| 3 | Longhorn | longhorn-system | Distributed storage (2 replicas) |
-| 4 | Prometheus Stack | monitoring | Grafana, Prometheus, Alertmanager |
+| 3 | Prometheus Stack | monitoring | Grafana, Prometheus, Alertmanager |
+| 4 | Longhorn | longhorn-system | Distributed storage (2 replicas) |
 | 5 | Portainer | portainer | Agent connects to 10.10.81.81:9001 |
 
 ### 4.2 Verify Addons
@@ -404,8 +404,8 @@ ansible-playbook -i inventories/server/hosts.yml playbooks/addons.yml
 
 ```bash
 # Backup etcd (K3s stores in /var/lib/rancher/k3s/server/db/)
-ssh ubuntu@10.10.88.73 "sudo tar czf /tmp/k3s-backup.tar.gz /var/lib/rancher/k3s/server/db"
-scp ubuntu@10.10.88.73:/tmp/k3s-backup.tar.gz ~/backups/
+ssh root@10.10.88.73 "tar czf /tmp/k3s-backup.tar.gz /var/lib/rancher/k3s/server/db"
+scp root@10.10.88.73:/tmp/k3s-backup.tar.gz ~/backups/
 ```
 
 ---

--- a/docs/NPU-API.md
+++ b/docs/NPU-API.md
@@ -53,7 +53,7 @@ curl http://10.10.88.73:8080/models
 
 Response:
 ```json
-{"models": ["DeepSeek-R1-1.5B", "tinyllama-1.1b", "Qwen-1_8B-Chat"]}
+{"models": ["DeepSeek-R1-1.5B"]}
 ```
 
 ### GET /current_model - Show Loaded Model
@@ -340,11 +340,11 @@ To change the port:
 ```bash
 # Edit defaults in Ansible
 # ansible/roles/rknn/defaults/main.yml
-rkllama_service_port: 8081
+rknn_service_port: 8081
 
-# Or edit service file directly
+# Or override the unit directly — the port is a --port CLI flag, not an env var
 sudo systemctl edit rkllama
-# Add: Environment="PORT=8081"
+# Add an ExecStart override under [Service] that repeats the command above with --port 8081
 sudo systemctl daemon-reload
 sudo systemctl restart rkllama
 ```

--- a/docs/VAULT-SETUP.md
+++ b/docs/VAULT-SETUP.md
@@ -2,8 +2,8 @@
 
 This document explains how to configure Ansible Vault for secure secrets management in this repository.
 
-> **Note:** Vault is opt-in. The default `inventories/server/hosts.yml` keeps
-> secrets in plain text (gitignored alongside `.example`). The steps below
+> **Note:** Vault is opt-in. The default `secrets/server.yml` keeps
+> secrets in plain text (gitignored alongside its `.example`). The steps below
 > show how to switch to a vault-encrypted workflow if you want that — it's
 > not required for the playbooks to run.
 

--- a/scripts/download-armbian-image.sh
+++ b/scripts/download-armbian-image.sh
@@ -68,7 +68,7 @@ Examples:
   DOWNLOAD_DIR=/tmp ./download-armbian-image.sh --latest
 
   # Download from direct URL
-  ./download-armbian-image.sh https://armbian-builds.techki.to/turing-rk1/armbian/26.02.0-trunk/Armbian.img.xz
+  ./download-armbian-image.sh https://armbian-builds.techki.to/turing-rk1/armbian/26.08.0-trunk/Armbian.img.xz
 
 EOF
     exit 1


### PR DESCRIPTION
## Summary

Audited all 13 documentation files against the live repo and fixed verified staleness. No source/behavior changes — docs and one usage comment only.

### Version drift (`images.json` is on `26.08.0-trunk`)
- `26.02.0-trunk` → `26.08.0-trunk` in `README.md`, `INSTALL.md` (×3), `docs/ARMBIAN-BUILD.md` (×5), `scripts/download-armbian-image.sh`
- Fixed the `README.md` pre-built link, which also omitted the `armbian/` path segment (404'd even for the old version)

### Factual corrections
- **Addon deploy order**: docs claimed Longhorn before Prometheus; `ansible/playbooks/addons.yml` deploys `prometheus_stack` **before** `longhorn`. Fixed in `ARCHITECTURE.md` (×2) and `IMPLEMENTATION.md`.
- **NPU-API**: `rkllama_service_port` → `rknn_service_port` (the documented variable was never read); trimmed the `/models` example to the only shipped model (`DeepSeek-R1-1.5B`); fixed the port-change snippet (the unit uses a `--port` flag, not `Environment=PORT`).
- **VAULT-SETUP**: plaintext-secrets note now points at `secrets/server.yml` (the gitignored file) instead of the tracked, secret-free `hosts.yml`.
- **INSTALL**: removed the false "creates `/root/provisioning.sh`" claim; the prepare script writes SSH keys / hostname / `/etc/hosts` directly into the mounted image.
- **IMPLEMENTATION**: `ssh ubuntu@` → `root@` (inventory uses `ansible_user: root`); completed the base-package list and corrected the kernel-module list to the set the `base` role actually loads (`br_netfilter, overlay, iscsi_tcp`).

### CHANGELOG
- Recorded the `26.08.0-trunk` image bump under `[Unreleased]`.
- De-duplicated the `[1.4.0]` section (removed misfiled bullets and duplicate `Added`/`Fixed`/`Compatibility` headings from a botched backfill).

### Related (already pushed, not in this PR)
The CHANGELOG footer's broken compare-links were fixed separately by creating the 3 missing git tags (`v0.1.0`, `v1.1.5`, `v1.2.0`) and their GitHub Releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)