### PR TITLE
ci(release): harden changelog generation step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,17 +19,23 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        shell: bash
         run: |
-          # Get commits since last tag (or all commits if first release)
+          set -euo pipefail
+          # Commits since the previous tag, or all commits for the first release.
+          # describe HEAD^ so the tag being released isn't its own "previous tag";
+          # it fails (caught) at the root commit, falling back to the full log.
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           if [ -n "$PREV_TAG" ]; then
-            CHANGES=$(git log --pretty=format:"- %s" $PREV_TAG..HEAD)
+            CHANGES=$(git log --pretty=format:"- %s" "$PREV_TAG"..HEAD)
           else
             CHANGES=$(git log --pretty=format:"- %s")
           fi
-          echo "changes<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "changes<<EOF"
+            echo "$CHANGES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0


### PR DESCRIPTION
## Summary

Belt-and-suspenders hardening of the `Generate changelog` step in `release.yml`. **No behavior change** for normal releases — the step produces the same changelog; it just fails loudly instead of silently on unexpected errors, and is robust against future edits.

### Changes
- Add `set -euo pipefail` and an explicit `shell: bash`
- Quote `"$PREV_TAG"` and `"$GITHUB_OUTPUT"`
- Group the `GITHUB_OUTPUT` heredoc writes into a single redirect

### Context
The `v0.1.0` release run failed at this step because GitHub Actions runs the workflow file *as it existed at the tagged commit*, and at the repo's root commit `release.yml` still had the old `HEAD~10..HEAD` fallback (which fails with <10 commits). That bug was already fixed on `main` in `7885f64`; this PR doesn't re-fix it (it can't — that's a historical snapshot) but makes the current, correct logic resilient.

### Verified
- YAML parses (`yaml.safe_load`)
- `yamllint -c .yamllint` adds no new warnings (the two existing `document-start`/`truthy` warnings are pre-existing and untouched)
- Traced all three paths (root commit, first-tag-not-root, normal release) — behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)