### PR TITLE
test: verify no-admin merge

### DIFF
--- a/merge-verify.md
+++ b/merge-verify.md
@@ -1,0 +1,5 @@
+# Merge verification (transient)
+
+This file is a throwaway artifact to verify that a green-CI PR merges into
+`main` without an `--admin` bypass after the branch-protection review gate was
+removed. It is reverted immediately after the check.


### PR DESCRIPTION
Throwaway PR to confirm a green-CI PR now merges without `--admin` after dropping the required code-owner review. Will be reverted immediately.