### PR TITLE
test: remove merge-verification artifact

### DIFF
--- a/merge-verify.md
+++ b/merge-verify.md
@@ -1,5 +1,0 @@
-# Merge verification (transient)
-
-This file is a throwaway artifact to verify that a green-CI PR merges into
-`main` without an `--admin` bypass after the branch-protection review gate was
-removed. It is reverted immediately after the check.


### PR DESCRIPTION
Reverts the throwaway `merge-verify.md` from #18. Restores `main` to its pre-test state.