### PR TITLE
test: remove bot-review verification artifact

### DIFF
--- a/bot-review-check.md
+++ b/bot-review-check.md
@@ -1,5 +1,0 @@
-# Bot-review verification (transient)
-
-Throwaway artifact to verify that, with the review gate re-enabled, the
-auto-approve workflow's github-actions[bot] approval actually satisfies the
-required review (so an owner PR merges without `--admin`). Reverted right after.


### PR DESCRIPTION
Reverts the throwaway `bot-review-check.md` from #21. Also re-confirms the bot auto-approve + gate flow.