### PR TITLE
ci: harden auto-approve workflow (concurrency, scope, error handling)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,10 +10,17 @@ name: Auto-approve owner PRs
 
 on:
   pull_request:
+    branches: [main]
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
   pull-requests: write
+
+# Collapse a push-burst (multiple synchronize events) into a single run so we
+# don't post duplicate approvals or waste runner minutes.
+concurrency:
+  group: auto-approve-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   approve:
@@ -26,10 +33,22 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              event: 'APPROVE',
-              body: 'Auto-approved: PR by the repository owner (sole code owner cannot self-approve).',
-            });
+            try {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                event: 'APPROVE',
+                body: 'Auto-approved: PR by the repository owner (sole code owner cannot self-approve).',
+              });
+            } catch (err) {
+              // A PR that was closed/merged (404) or is no longer reviewable
+              // (422) by the time this runs is not a real failure. Anything else
+              // — e.g. a 403 from a fork PR's read-only token — must still fail
+              // the run so an unsatisfiable review gate is visible.
+              if (err.status === 404 || err.status === 422) {
+                core.warning(`Skipped approval: ${err.message}`);
+              } else {
+                throw err;
+              }
+            }


### PR DESCRIPTION
Robustness fixes from a review of the owner auto-approve workflow. No change to the approve/skip decision for normal owner PRs — these only make the workflow safer and quieter.

## Changes
- **`branches: [main]`** — only auto-approve PRs targeting the protected branch, so the rubber-stamp can't silently extend to other protected branches added later.
- **`concurrency` group with `cancel-in-progress`** — collapse a push-burst (multiple `synchronize` events) into a single run instead of posting duplicate bot approvals and burning runner minutes.
- **`try/catch` around `createReview`** — swallow only `404`/`422` (PR closed or no longer reviewable by the time the job runs) as a `core.warning`, but re-throw anything else (e.g. a `403` from a fork PR's read-only token) so an unsatisfiable review gate still surfaces as a failed run.

## Not changed (deliberate)
- `synchronize` re-approval and the unconditional approve are design tradeoffs for a solo-owner repo.
- The hardcoded owner login stays — `github.repository_owner` would resolve to the org (`freed-dev-llc`) and never match the author.