### PR TITLE
ci: pin lint tooling, widen yamllint scope, pin terraform provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install ansible ansible-lint yamllint
+          pip install ansible "ansible-lint==26.4.0" "yamllint==1.38.0"
 
       - name: Create empty vault password file
         working-directory: ansible
@@ -29,9 +29,8 @@ jobs:
           echo "ci-dummy-password" > .vault_pass
 
       - name: Run yamllint
-        working-directory: ansible
         run: |
-          yamllint -c ../.yamllint .
+          yamllint -c .yamllint .
 
       - name: Run ansible-lint
         working-directory: ansible

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.tfvars
 !*.tfvars.example
 .terraform/
-.terraform.lock.hcl
+# .terraform.lock.hcl is intentionally committed to pin provider versions/checksums
 crash.log
 override.tf
 override.tf.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
 
   # YAML linting
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args: [-c, .yamllint]
@@ -31,7 +31,7 @@ repos:
 
   # Ansible linting
   - repo: https://github.com/ansible/ansible-lint
-    rev: v25.1.3
+    rev: v26.4.0
     hooks:
       - id: ansible-lint
         name: ansible-lint
@@ -39,6 +39,7 @@ repos:
         language: python
         files: \.(yml|yaml)$
         exclude: ^(ansible/roles/geerlingguy|\.github/)
+        pass_filenames: false
         args:
           - --config-file=ansible/.ansible-lint
           - ansible/

--- a/terraform/environments/server/.terraform.lock.hcl
+++ b/terraform/environments/server/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/jfreed-dev/turingpi" {
+  version     = "1.4.0"
+  constraints = "~> 1.4"
+  hashes = [
+    "h1:COeWXH9Gwf6LyV0PKVoJ36foDJMD8hITsfh7izw9aG0=",
+    "h1:g+1JhlB24QUhVWNY0RXxGvSa8Yh9svsiQ08YChrqpjE=",
+    "h1:n02I8M+31++lkC4vqYdMjoCEsD0pOe0OGpkpLR3zY+I=",
+    "h1:vS/qz7HdPBmo4x3PuMEdKW880iblRFoYTWm1Unw4odk=",
+    "zh:121b3f1798d4392a3e0eb6814ac32d90a558203008220e044390db9d23009e7f",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:3d6123a12ea914b0d315425224d01b9b0c94173e4e0b45469f102106e7a908cd",
+    "zh:4f8bfe082b181899c32b2a2ab56adc64a834767a1615b16b71f78704e85b2cfd",
+    "zh:8e15b96f1c28db1c560cf276945a902f30c952b27cc91ce5e0b494ca5ec3e4f9",
+    "zh:bba33a7ea0227f6ac838f65234a3110b0b44e0774ced70c06bb63ebe684e0a26",
+    "zh:e6678e69f6c5a6826aa809b8b5fd585ba541c50ed4f94d105df0c18f5ce193e7",
+  ]
+}

--- a/terraform/environments/server/main.tf
+++ b/terraform/environments/server/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     turingpi = {
       source  = "jfreed-dev/turingpi"
-      version = ">= 1.0.10"
+      version = "~> 1.4"
     }
   }
 }

--- a/terraform/modules/bmc/main.tf
+++ b/terraform/modules/bmc/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     turingpi = {
       source  = "jfreed-dev/turingpi"
-      version = ">= 1.0.10"
+      version = "~> 1.4"
     }
   }
 }


### PR DESCRIPTION
Hardening from an audit of `.yamllint`, `.pre-commit-config.yaml`, and `terraform/`. No runtime behavior change — only lint coverage/reproducibility and provider pinning.

## Lint consistency
- **`ci.yml`** — run `yamllint` from the **repo root** so `.github/` workflows and root YAML are linted in CI (previously only `ansible/` was, so a malformed workflow merged green). Pin CI linters: `ansible-lint==26.4.0`, `yamllint==1.38.0` (the versions already resolved by "latest"), so an upstream release can't silently flip results.
- **`.pre-commit-config.yaml`** — bump `yamllint` → `v1.38.0` and `ansible-lint` → `v26.4.0` to match CI; add `pass_filenames: false` to the ansible-lint hook so it lints `ansible/` once instead of `ansible/` **plus** every changed YAML file.

## Terraform provider pinning
- Pin `jfreed-dev/turingpi` to **`~> 1.4`** (was `>= 1.0.10`) in the root config and the `bmc` module, so `init`/`tofu init` can't jump to a future major.
- Commit **`.terraform.lock.hcl`** with multi-platform checksums (linux/darwin × amd64/arm64) for **v1.4.0**, and stop gitignoring the lock file.

## Validation
- `terraform validate` ✓, `terraform fmt -check` ✓
- `yamllint -c .yamllint .` from root → exit 0 (warnings-only, non-blocking)
- lock resolved `~> 1.4` → `1.4.0` (latest on the registry)