### PR TITLE
feat(armbian): keep-3 R2 retention + history cap, README version badge

### DIFF
--- a/.github/workflows/armbian-build.yml
+++ b/.github/workflows/armbian-build.yml
@@ -222,7 +222,7 @@ jobs:
             armbian_version: $version,
             build_date: $date,
             download_url: $download_url
-          }] + .history[0:9])' images.json > images.json.tmp && mv images.json.tmp images.json
+          }] + .history[0:2])' images.json > images.json.tmp && mv images.json.tmp images.json
 
           echo "Updated images.json:"
           cat images.json
@@ -266,7 +266,7 @@ jobs:
               version: $prev_version,
               build_date: $prev_date,
               download_url: $prev_url
-            }] + (.armbian.history // [])[0:9])
+            }] + (.armbian.history // [])[0:1])
           else
             .
           end) |
@@ -300,6 +300,27 @@ jobs:
           # Upload to R2
           rclone copy r2-images.json "r2:${BUCKET}/turing-rk1/" --progress
           echo "Unified images.json uploaded to R2"
+
+      - name: Prune old image versions in R2 (keep newest 3)
+        run: |
+          BUCKET="armbian-builds"
+          KEEP=3
+          LATEST="${{ needs.check-version.outputs.upstream_version }}"
+          # Version dirs sort chronologically (Armbian uses YY.MM.x); keep the
+          # newest $KEEP and purge the rest. Never delete the version just built.
+          rclone lsf --dirs-only "r2:${BUCKET}/turing-rk1/armbian/" \
+            | sed 's:/*$::' | sort -V | head -n "-${KEEP}" \
+            | while read -r v; do
+                [ -z "$v" ] && continue
+                if [ "$v" = "$LATEST" ]; then
+                  echo "Keeping current latest: $v"
+                  continue
+                fi
+                echo "Pruning old version: $v"
+                rclone purge "r2:${BUCKET}/turing-rk1/armbian/${v}/" || echo "WARN: failed to prune $v"
+              done
+          echo "Versions retained in R2:"
+          rclone lsf --dirs-only "r2:${BUCKET}/turing-rk1/armbian/"
 
       - name: Commit and push changes
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Turing RK1 Ansible Cluster
 
 [![CI](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml/badge.svg)](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml)
+[![Armbian Build](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/armbian-build.yml/badge.svg)](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/armbian-build.yml)
+[![Armbian image](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/freed-dev-llc/turing-ansible-cluster/main/images.json&query=$.latest.armbian_version&label=Armbian%20image&color=blue)](docs/ARMBIAN-BUILD.md)
+[![Release](https://img.shields.io/github/v/release/freed-dev-llc/turing-ansible-cluster?sort=semver&color=blue)](https://github.com/freed-dev-llc/turing-ansible-cluster/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Infrastructure-as-code for deploying K3s Kubernetes on Turing Pi RK1 hardware with NPU support.
@@ -29,7 +32,7 @@ Deploy a 4-node K3s cluster on Turing Pi with:
 - Terraform >= 1.5
 - Ansible >= 2.15
 - Turing Pi BMC access
-- Armbian image (see [Building Armbian](#building-armbian) or [download pre-built](https://armbian-builds.techki.to/turing-rk1/armbian/26.08.0-trunk/Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz))
+- Armbian image (see [Building Armbian](#building-armbian) or [download pre-built](#image-distribution)) — current version shown by the **Armbian image** badge above
 
 ## Quick Start
 


### PR DESCRIPTION
Adds a lifecycle/retention policy for the Armbian images in R2, caps the manifests to match, and surfaces the live image version in the README.

## Retention (keep newest 3)
- **`armbian-build.yml`** — new prune step after the upload/manifest steps: lists version dirs under `turing-rk1/armbian/`, keeps the newest 3 (`sort -V | head -n -3`), and `rclone purge`s the older ones. Guards against ever deleting the version just built. Purge failures warn instead of failing the build.
- **History caps** — both manifests now keep 3 *total* so no `history` entry references a purged object: repo `images.json` `.history[0:2]`; R2 `r2-images.json` `.armbian.history[0:1]` (latest is stored separately, so 2 prior + latest = 3).

Why count-based in the workflow rather than an R2 lifecycle rule: builds are infrequent/irregular (only when Armbian bumps its `VERSION`, ~quarterly), so an age-based R2 rule could delete the *live* latest during a quiet stretch. R2 native lifecycle can't express "keep newest N".

## README
- New badges: **Armbian Build** status, a dynamic **Armbian image** version badge read live from `images.json` (so the specific version is shown without a hardcoded string that goes stale), and a **Release** badge (`sort=semver` → shows the highest tag, since the tag history is out of order from CI-gate testing).
- De-pinned the prerequisites download link that hardcoded `26.08.0-trunk`.

## Validation
- Prune pipeline simulated: keeps newest 3, handles year rollover (25.x < 26.x), deletes nothing at ≤3.
- `yamllint` clean on the workflow; both shields badges verified to render (`Armbian image: 26.08.0-trunk`, `release: v1.4.0`).

Note: prune only takes effect on the next real build (next upstream Armbian version bump); existing extra versions already in R2 won't be removed until then.