### PR TITLE
fix(ansible): retry external fetches, guard wait loops, resolve no-handler

### DIFF
--- a/ansible/playbooks/addons.yml
+++ b/ansible/playbooks/addons.yml
@@ -21,6 +21,10 @@
       args:
         creates: /usr/local/bin/helm
         executable: /bin/bash
+      register: addons_helm_install
+      until: addons_helm_install is succeeded
+      retries: 3
+      delay: 10
 
     - name: Install Python kubernetes module
       ansible.builtin.apt:

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -3,12 +3,19 @@
   ansible.builtin.apt:
     update_cache: true
     cache_valid_time: 3600
+  register: base_apt_cache
+  until: base_apt_cache is succeeded
+  retries: 3
+  delay: 5
 
 - name: Install base packages
   ansible.builtin.apt:
     name: "{{ base_packages }}"
     state: present
   register: base_packages_installed
+  until: base_packages_installed is succeeded
+  retries: 3
+  delay: 5
 
 - name: Load required kernel modules
   community.general.modprobe:
@@ -55,7 +62,7 @@
 
 - name: Set timezone
   community.general.timezone:
-    name: "{{ base_timezone | default('America/Chicago') }}"
+    name: "{{ base_timezone }}"
 
 # iSCSI configuration for Longhorn
 - name: Configure iSCSI for Longhorn

--- a/ansible/roles/k3s_agent/tasks/main.yml
+++ b/ansible/roles/k3s_agent/tasks/main.yml
@@ -38,6 +38,11 @@
     url: https://get.k3s.io
     dest: /tmp/k3s-install.sh
     mode: "0755"
+    timeout: 30
+  register: k3s_agent_install_script
+  until: k3s_agent_install_script is succeeded
+  retries: 3
+  delay: 5
   when: not k3s_agent_binary.stat.exists
 
 # Security: The install script verifies the k3s binary using SHA256 checksums
@@ -50,7 +55,6 @@
   ansible.builtin.command: /tmp/k3s-install.sh agent
   args:
     creates: /usr/local/bin/k3s
-  register: k3s_agent_install
 
 - name: Verify k3s binary version matches expected
   ansible.builtin.command: /usr/local/bin/k3s --version

--- a/ansible/roles/k3s_server/handlers/main.yml
+++ b/ansible/roles/k3s_server/handlers/main.yml
@@ -4,3 +4,11 @@
     name: k3s
     state: restarted
     daemon_reload: true
+
+- name: Update local kubeconfig server address
+  delegate_to: localhost
+  become: false
+  ansible.builtin.replace:
+    path: "{{ kubeconfig_dir }}/kubeconfig"
+    regexp: 'https://127.0.0.1:6443'
+    replace: "https://{{ ansible_host }}:6443"

--- a/ansible/roles/k3s_server/tasks/main.yml
+++ b/ansible/roles/k3s_server/tasks/main.yml
@@ -22,6 +22,11 @@
     url: https://get.k3s.io
     dest: /tmp/k3s-install.sh
     mode: "0755"
+    timeout: 30
+  register: k3s_server_install_script
+  until: k3s_server_install_script is succeeded
+  retries: 3
+  delay: 5
   when: not k3s_server_binary.stat.exists
 
 # Security: The install script verifies the k3s binary using SHA256 checksums
@@ -74,14 +79,4 @@
     flat: true
   run_once: true
   when: not k3s_server_local_kubeconfig.stat.exists
-  register: k3s_server_kubeconfig_fetched
-
-- name: Update kubeconfig server address
-  delegate_to: localhost
-  become: false
-  ansible.builtin.replace:
-    path: "{{ kubeconfig_dir }}/kubeconfig"
-    regexp: 'https://127.0.0.1:6443'
-    replace: "https://{{ ansible_host }}:6443"
-  run_once: true
-  when: k3s_server_kubeconfig_fetched.changed | default(false)
+  notify: Update local kubeconfig server address

--- a/ansible/roles/longhorn/tasks/main.yml
+++ b/ansible/roles/longhorn/tasks/main.yml
@@ -16,6 +16,10 @@
     name: longhorn
     repo_url: https://charts.longhorn.io
     state: present
+  register: longhorn_helm_repo
+  until: longhorn_helm_repo is succeeded
+  retries: 3
+  delay: 10
 
 - name: Create Longhorn namespace
   kubernetes.core.k8s:
@@ -48,7 +52,9 @@
     namespace: longhorn-system
     name: longhorn-driver-deployer
   register: longhorn_deployer
-  until: longhorn_deployer.resources[0].status.readyReplicas | default(0) >= 1
+  until: >-
+    (longhorn_deployer.resources | length > 0) and
+    (longhorn_deployer.resources[0].status.readyReplicas | default(0) >= 1)
   retries: 30
   delay: 10
 

--- a/ansible/roles/metallb/tasks/main.yml
+++ b/ansible/roles/metallb/tasks/main.yml
@@ -4,6 +4,10 @@
     name: metallb
     repo_url: https://metallb.github.io/metallb
     state: present
+  register: metallb_helm_repo
+  until: metallb_helm_repo is succeeded
+  retries: 3
+  delay: 10
 
 - name: Create MetalLB namespace
   kubernetes.core.k8s:
@@ -35,7 +39,9 @@
     namespace: metallb-system
     name: metallb-controller
   register: metallb_controller
-  until: metallb_controller.resources[0].status.readyReplicas | default(0) >= 1
+  until: >-
+    (metallb_controller.resources | length > 0) and
+    (metallb_controller.resources[0].status.readyReplicas | default(0) >= 1)
   retries: 30
   delay: 10
 

--- a/ansible/roles/nginx_ingress/tasks/main.yml
+++ b/ansible/roles/nginx_ingress/tasks/main.yml
@@ -4,6 +4,10 @@
     name: ingress-nginx
     repo_url: https://kubernetes.github.io/ingress-nginx
     state: present
+  register: nginx_ingress_helm_repo
+  until: nginx_ingress_helm_repo is succeeded
+  retries: 3
+  delay: 10
 
 - name: Create ingress-nginx namespace
   kubernetes.core.k8s:
@@ -43,6 +47,8 @@
     namespace: ingress-nginx
     name: ingress-nginx-controller
   register: nginx_ingress_controller
-  until: nginx_ingress_controller.resources[0].status.readyReplicas | default(0) >= 1
+  until: >-
+    (nginx_ingress_controller.resources | length > 0) and
+    (nginx_ingress_controller.resources[0].status.readyReplicas | default(0) >= 1)
   retries: 30
   delay: 10

--- a/ansible/roles/prometheus_stack/tasks/main.yml
+++ b/ansible/roles/prometheus_stack/tasks/main.yml
@@ -4,6 +4,10 @@
     name: prometheus-community
     repo_url: https://prometheus-community.github.io/helm-charts
     state: present
+  register: prometheus_helm_repo
+  until: prometheus_helm_repo is succeeded
+  retries: 3
+  delay: 10
 
 - name: Create monitoring namespace
   kubernetes.core.k8s:

--- a/ansible/roles/rknn/tasks/main.yml
+++ b/ansible/roles/rknn/tasks/main.yml
@@ -31,6 +31,10 @@
     dest: /opt/rknn-llm
     version: main
     depth: 1
+  register: rknn_llm_clone
+  until: rknn_llm_clone is succeeded
+  retries: 3
+  delay: 10
 
 - name: Install RKNN runtime library from rknn-llm
   ansible.builtin.shell: |
@@ -57,6 +61,10 @@
     version: main
     depth: 1
     force: true
+  register: rknn_rkllama_clone
+  until: rknn_rkllama_clone is succeeded
+  retries: 3
+  delay: 10
 
 - name: Remove existing lib directory if not a symlink
   ansible.builtin.file:
@@ -87,6 +95,10 @@
     state: present
     virtualenv: "{{ rknn_venv_path }}"
     extra_args: --upgrade
+  register: rknn_pip_upgrade
+  until: rknn_pip_upgrade is succeeded
+  retries: 3
+  delay: 10
 
 - name: Install rkllama Python dependencies in venv
   ansible.builtin.pip:
@@ -97,6 +109,10 @@
       - transformers
       - numpy
     virtualenv: "{{ rknn_venv_path }}"
+  register: rknn_pip_deps
+  until: rknn_pip_deps is succeeded
+  retries: 3
+  delay: 10
 
 - name: Create RKNN environment script
   ansible.builtin.copy:
@@ -124,7 +140,8 @@
     - not rknn_skip_model_download
     - not rknn_model_file.stat.exists
   register: rknn_model_download
-  retries: 2
+  until: rknn_model_download is succeeded
+  retries: 3
   delay: 10
 
 - name: Display model download status  # noqa: no-handler


### PR DESCRIPTION
Reliability + lint hardening across the Ansible roles, from an audit of the `ansible/` folder. No success-path behavior change.

## Why
CI just flaked on a `get.k3s.io` read-timeout in the `k3s_server` molecule run. This hardens that and every similar unguarded external fetch, and clears the one outstanding ansible-lint warning.

## Retry transient external fetches (`register` + `until ... is succeeded` + `retries`/`delay`)
- **k3s_server / k3s_agent** — `get.k3s.io` install-script download (+`timeout: 30`); directly fixes the observed flake.
- **base** — `apt` cache update + package install.
- **longhorn / metallb / nginx_ingress / prometheus_stack** — `helm_repository` index fetch.
- **addons.yml** — the `curl|bash` Helm install.
- **rknn** — both `git` clones + both `pip` installs, and the missing `until` on the model `get_url` (**dead-retry bug**: ansible-core silently disables `retries` when `until` is absent, so its `retries: 2` never fired).

## Guard the readiness waits
`longhorn` / `metallb` / `nginx_ingress` `until: <reg>.resources[0]...` now check `resources | length > 0` first, so an empty list during rollout **retries** instead of raising `IndexError`.

## Cleanups
- **k3s_server** — the changed-gated kubeconfig rewrite is now a proper **handler** notified by `Fetch kubeconfig` → resolves the `no-handler` warning; **ansible-lint production profile now passes with 0 warnings (was 3/5★)**.
- **k3s_agent** — drop unused `register: k3s_agent_install`.
- **base** — drop redundant inline timezone default (`base_timezone` is in defaults).

## Not done (deliberate)
- Helm **install** tasks aren't retried — they use `wait: true` with long timeouts, so retrying means 3× the wait on a convergence stall; the repo-index retry covers the network-flake case.
- Deferred as follow-ups: the dormant `k3s_prereq` `registries.yaml.j2` template, `portainer`/`prometheus_stack` lacking `defaults/`, and the `prometheus` `playbook_dir` template path.

## Validation
- `ansible-lint` → production profile passes, 0 warnings/0 failures.
- `yamllint` → clean.
- `ansible-playbook --syntax-check` → all 6 playbooks OK.
- CI molecule covers `base` + `k3s_server` (both touched); other roles are lint + syntax-check only.