### PR TITLE
chore: repo hygiene - drop dead config, tighten lint, fix manifest/changelog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,6 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
         args: [--unsafe]  # Allow custom tags in Ansible
-        exclude: ^ansible/roles/geerlingguy
       - id: check-added-large-files
         args: [--maxkb=1024]
       - id: check-merge-conflict
@@ -27,7 +26,6 @@ repos:
     hooks:
       - id: yamllint
         args: [-c, .yamllint]
-        exclude: ^ansible/roles/geerlingguy
 
   # Ansible linting
   - repo: https://github.com/ansible/ansible-lint
@@ -38,7 +36,7 @@ repos:
         entry: ansible-lint
         language: python
         files: \.(yml|yaml)$
-        exclude: ^(ansible/roles/geerlingguy|\.github/)
+        exclude: ^\.github/
         pass_filenames: false
         args:
           - --config-file=ansible/.ansible-lint
@@ -74,7 +72,7 @@ repos:
     hooks:
       - id: markdownlint
         args: [--disable, MD013, MD033, MD041, --]  # Disable line-length, inline HTML, first-line heading
-        exclude: ^(CHANGELOG\.md|ansible/roles/geerlingguy)
+        exclude: ^CHANGELOG\.md
 
 # CI configuration
 ci:

--- a/.yamllint
+++ b/.yamllint
@@ -23,5 +23,3 @@ ignore: |
   .ansible/
   .git/
   ansible/.ansible/
-  ansible/roles/geerlingguy.*
-  roles/geerlingguy.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Armbian R2 lifecycle: a prune step keeps only the newest 3 image versions and the manifests cap history to match; README gains live Armbian-version, build-status, and release badges (#25).
+- CI lints `.github/` and repo-root YAML (yamllint runs from the repo root) and pins its linters to the pre-commit versions (#24).
+
 ### Changed
 
 - `ansible/inventories/server/hosts.yml.example` k3s_version bumped from v1.31.3 to v1.31.4+k3s1 (pass-5 missed this template file; live `hosts.yml` was already on v1.31.4).
 - Armbian image metadata bumped to `26.08.0-trunk` (build 2026-06-06, kernel 6.1.115) in `images.json` (`eb1d3f0`).
+- Hardened Ansible network operations against flaky CI — get.k3s.io downloads, Helm repo fetches, git/pip installs, apt, and the Helm installer now retry; Kubernetes readiness waits are index-safe (#26).
+- Pinned the `jfreed-dev/turingpi` Terraform provider to `~> 1.4` with a committed multi-platform `.terraform.lock.hcl`; scoped the owner auto-approve workflow to `main` with a concurrency guard (#23, #24).
+- `make install-deps` pins ansible-lint/yamllint to the CI versions and `make lint` no longer swallows yamllint failures; `.ansible-lint` now enforces `no-handler` (this PR).
+
+### Fixed
+
+- `k3s_server` kubeconfig rewrite converted to a handler, resolving the ansible-lint `no-handler` warning (production profile now passes clean); the `rknn` model download's retries now take effect via a missing `until` (#26).
 
 ### Removed
 
 - Dead `rknn_version: "2.3.2"` variable from `ansible/inventories/server/hosts.yml` + `.example`. The role at `ansible/roles/rknn/tasks/main.yml` clones HEAD of `airockchip/rknn-llm`; this variable was never read. INSTALL.md and ARCHITECTURE.md correctly cite v1.2.1.
+- Unused `geerlingguy.docker` / `geerlingguy.pip` Galaxy role dependencies (never referenced by any play or role) and their now-vestigial lint excludes in `.yamllint`, `.ansible-lint`, and `.pre-commit-config.yaml` (this PR).
 
 ## [1.4.0] - 2026-05-19
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: help lint test syntax-check install-deps clean release \
         pre-commit pre-commit-install pre-commit-update \
         vault-init vault-edit vault-view vault-encrypt vault-decrypt \
-        molecule molecule-test molecule-verify molecule-destroy
+        molecule molecule-test molecule-verify molecule-destroy molecule-all
 
 # Default target
 help:
@@ -42,12 +42,12 @@ help:
 
 # Install development dependencies
 install-deps:
-	pip install ansible ansible-lint yamllint pre-commit shellcheck-py molecule molecule-docker
+	pip install ansible "ansible-lint==26.4.0" "yamllint==1.38.0" pre-commit shellcheck-py molecule molecule-docker
 
 # Run linting
 lint:
 	@echo "Running yamllint..."
-	yamllint -c .yamllint ansible/ || true
+	yamllint -c .yamllint ansible/
 	@echo ""
 	@echo "Running ansible-lint..."
 	cd ansible && ansible-lint

--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -4,7 +4,6 @@
 exclude_paths:
   - .ansible/
   - .cache/
-  - roles/geerlingguy.*/
 
 # Skip these rules for specific patterns
 skip_list:
@@ -13,7 +12,6 @@ skip_list:
 # Warn on these instead of failing
 warn_list:
   - yaml[line-length]
-  - no-handler  # Some tasks use when: changed but don't fit handler pattern
 
 # Enable offline mode for faster runs
 offline: true

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -7,9 +7,3 @@ collections:
     version: "12.1.0"
   - name: ansible.posix
     version: "2.1.0"
-
-roles:
-  - name: geerlingguy.docker
-    version: "7.4.1"
-  - name: geerlingguy.pip
-    version: "3.0.0"

--- a/images.json
+++ b/images.json
@@ -25,11 +25,6 @@
       "armbian_version": "26.02.0-trunk",
       "build_date": "2025-12-26",
       "download_url": "https://armbian-builds.techki.to/turing-rk1/armbian/26.02.0-trunk/Armbian-unofficial_26.02.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz"
-    },
-    {
-      "armbian_version": "26.02.0-trunk",
-      "build_date": "2025-12-24",
-      "release_url": null
     }
   ],
   "build_config": {


### PR DESCRIPTION
Bundles the easy fixes surfaced by audits of `images.json`, `Makefile`, `CHANGELOG.md`, `ansible.cfg`, `.ansible-lint`, and `requirements.yml`.

## Makefile
- Pin `install-deps` linters to the CI versions (`ansible-lint==26.4.0`, `yamllint==1.38.0`) so local `make lint` == CI.
- Drop `|| true` on the yamllint step — `make lint`/`make test` no longer silently pass on yamllint errors.
- Add `molecule-all` to `.PHONY`.

## Dead Galaxy deps + lint excludes
- Remove unused `geerlingguy.docker` / `geerlingguy.pip` roles from `requirements.yml` — never referenced by any play or role (the only `geerlingguy` usage is the Molecule *container image*, unrelated).
- Remove their now-vestigial excludes from `.yamllint`, `.ansible-lint`, and `.pre-commit-config.yaml`.

## Lint tightening
- `.ansible-lint`: drop `no-handler` from `warn_list` so it's **enforced** now that the tree is clean (PR #26 fixed the one real case; `rknn` keeps an explicit `# noqa`). Production profile still passes **0 failures / 0 warnings**.

## Manifest + changelog
- `images.json`: drop the malformed duplicate history entry (`release_url: null`, no `download_url`) — history is now 3 well-formed entries (also matches the keep-3 policy).
- `CHANGELOG.md`: backfill `[Unreleased]` with the #23–#26 CI / Terraform / Armbian / Ansible work plus this cleanup.

## Validation
- `ansible-lint` → production profile, 0/0 (with `no-handler` now enforced).
- `yamllint` (root) → clean; all edited YAML configs parse.
- `jq` → `images.json` valid, 3 history entries.
- `make -n test` → Makefile parses.

Left as deliberate follow-ups (not "easy"): `portainer`/`prometheus_stack` lacking `defaults/`, the `prometheus` `playbook_dir` template path, and the dormant `k3s_prereq` `registries.yaml.j2`.