### PR TITLE
docs(readme): add Turing RK1 cluster banner + icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Turing RK1 Ansible Cluster
 
+![Turing RK1 Ansible Cluster](docs/assets/turing-cluster/logos/turing_cluster_logo_horizontal.svg)
+
 [![CI](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml/badge.svg)](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml)
 [![Armbian Build](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/armbian-build.yml/badge.svg)](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/armbian-build.yml)
 [![Armbian image](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/freed-dev-llc/turing-ansible-cluster/main/images.json&query=$.latest.armbian_version&label=Armbian%20image&color=blue)](docs/ARMBIAN-BUILD.md)

--- a/docs/assets/turing-cluster/icons/turing_cluster_icon.svg
+++ b/docs/assets/turing-cluster/icons/turing_cluster_icon.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" width="240" height="240" role="img" aria-label="Turing RK1 cluster icon">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1A2C39"/>
+      <stop offset="1" stop-color="#0F1C25"/>
+    </linearGradient>
+    <linearGradient id="node" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#6E9DBA"/>
+      <stop offset="1" stop-color="#4E7C97"/>
+    </linearGradient>
+    <linearGradient id="cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#DB9560"/>
+      <stop offset="1" stop-color="#BE6C3A"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="2" y="2" width="236" height="236" rx="48" fill="url(#bg)" stroke="#2C4C61" stroke-width="2"/>
+
+  <g transform="translate(33,33)">
+    <g stroke="#4E7C97" fill="none" stroke-linecap="round">
+      <g opacity="0.5" stroke-width="4">
+        <line x1="36" y1="36" x2="138" y2="36"/>
+        <line x1="36" y1="138" x2="138" y2="138"/>
+        <line x1="36" y1="36" x2="36" y2="138"/>
+        <line x1="138" y1="36" x2="138" y2="138"/>
+      </g>
+      <g opacity="0.26" stroke-width="2.5">
+        <line x1="36" y1="36" x2="138" y2="138"/>
+        <line x1="138" y1="36" x2="36" y2="138"/>
+      </g>
+    </g>
+    <g stroke="#EAF2F7" stroke-opacity="0.10" stroke-width="1">
+      <rect x="0"   y="0"   width="72" height="72" rx="16" fill="url(#cp)"/>
+      <rect x="102" y="0"   width="72" height="72" rx="16" fill="url(#node)"/>
+      <rect x="0"   y="102" width="72" height="72" rx="16" fill="url(#node)"/>
+      <rect x="102" y="102" width="72" height="72" rx="16" fill="url(#node)"/>
+    </g>
+    <g>
+      <circle cx="36"  cy="36"  r="7.5" fill="#FBEEE3" opacity="0.92"/>
+      <circle cx="138" cy="36"  r="7.5" fill="#EAF2F7" opacity="0.85"/>
+      <circle cx="36"  cy="138" r="7.5" fill="#EAF2F7" opacity="0.85"/>
+      <circle cx="138" cy="138" r="7.5" fill="#EAF2F7" opacity="0.85"/>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/turing-cluster/logos/turing_cluster_logo_horizontal.svg
+++ b/docs/assets/turing-cluster/logos/turing_cluster_logo_horizontal.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 240" width="800" height="240" role="img" aria-label="Turing RK1 Ansible Cluster">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1A2C39"/>
+      <stop offset="1" stop-color="#0F1C25"/>
+    </linearGradient>
+    <linearGradient id="node" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#6E9DBA"/>
+      <stop offset="1" stop-color="#4E7C97"/>
+    </linearGradient>
+    <linearGradient id="cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#DB9560"/>
+      <stop offset="1" stop-color="#BE6C3A"/>
+    </linearGradient>
+  </defs>
+
+  <!-- panel -->
+  <rect x="1" y="1" width="798" height="238" rx="28" fill="url(#bg)" stroke="#2C4C61" stroke-width="1.5"/>
+
+  <!-- cluster icon: 2x2 nodes, control plane in copper -->
+  <g transform="translate(80,44)">
+    <g stroke="#4E7C97" fill="none" stroke-linecap="round">
+      <g opacity="0.5" stroke-width="3">
+        <line x1="30" y1="30" x2="114" y2="30"/>
+        <line x1="30" y1="114" x2="114" y2="114"/>
+        <line x1="30" y1="30" x2="30" y2="114"/>
+        <line x1="114" y1="30" x2="114" y2="114"/>
+      </g>
+      <g opacity="0.26" stroke-width="2">
+        <line x1="30" y1="30" x2="114" y2="114"/>
+        <line x1="114" y1="30" x2="30" y2="114"/>
+      </g>
+    </g>
+    <g stroke="#EAF2F7" stroke-opacity="0.10" stroke-width="1">
+      <rect x="0"  y="0"  width="60" height="60" rx="13" fill="url(#cp)"/>
+      <rect x="84" y="0"  width="60" height="60" rx="13" fill="url(#node)"/>
+      <rect x="0"  y="84" width="60" height="60" rx="13" fill="url(#node)"/>
+      <rect x="84" y="84" width="60" height="60" rx="13" fill="url(#node)"/>
+    </g>
+    <g>
+      <circle cx="30"  cy="30"  r="6" fill="#FBEEE3" opacity="0.92"/>
+      <circle cx="114" cy="30"  r="6" fill="#EAF2F7" opacity="0.85"/>
+      <circle cx="30"  cy="114" r="6" fill="#EAF2F7" opacity="0.85"/>
+      <circle cx="114" cy="114" r="6" fill="#EAF2F7" opacity="0.85"/>
+    </g>
+  </g>
+
+  <!-- wordmark -->
+  <g font-family="'Segoe UI','SF Pro Display',system-ui,-apple-system,'Helvetica Neue',Arial,sans-serif">
+    <text x="316" y="116" font-size="66" font-weight="800" letter-spacing="0.5" fill="#EAF2F7">TURING<tspan fill="#D2814E" dx="20">RK1</tspan></text>
+    <rect x="318" y="134" width="392" height="3" rx="1.5" fill="#D2814E" opacity="0.8"/>
+    <text x="320" y="168" font-size="19" font-weight="600" letter-spacing="4.4" fill="#7FA6BC">ANSIBLE · TERRAFORM · K3S · NPU</text>
+  </g>
+</svg>


### PR DESCRIPTION
Adds an SVG horizontal logo banner under the README title (matching the **reach** / **sisyphus** layout: `# Title` → logo → badges) plus a square icon asset for future use (favicon/social).

## Design
- **Mark:** a 2×2 node grid = the 4-node cluster, with the **control-plane node in copper** and the three workers in Niagara blue, joined by a faint interconnect mesh.
- **Wordmark:** `TURING RK1` with a copper "RK1", a thin copper rule, and an `ANSIBLE · TERRAFORM · K3S · NPU` subtitle, on a dark ink panel.
- **Palette:** built to complement **PANTONE 17-4139 TCX (Niagara denim-blue, ≈`#5B89A6`)** with a warm **copper** complement (`#D2814E`) — deliberately *not* the teal-green / purple-gradient "AI" look.

## Files
- `docs/assets/turing-cluster/logos/turing_cluster_logo_horizontal.svg` (referenced in README)
- `docs/assets/turing-cluster/icons/turing_cluster_icon.svg`

Self-contained dark panel so it renders identically in GitHub light/dark mode. Validated as well-formed SVG and rendered with `rsvg-convert` to verify before commit. Easy to iterate — tell me if you want a different accent, the wordmark restyled, or the icon motif changed.