### PR TITLE
style(banner): use a deeper terracotta accent instead of copper

### DIFF
--- a/docs/assets/turing-cluster/icons/turing_cluster_icon.svg
+++ b/docs/assets/turing-cluster/icons/turing_cluster_icon.svg
@@ -9,8 +9,8 @@
       <stop offset="1" stop-color="#4E7C97"/>
     </linearGradient>
     <linearGradient id="cp" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#DB9560"/>
-      <stop offset="1" stop-color="#BE6C3A"/>
+      <stop offset="0" stop-color="#C4683F"/>
+      <stop offset="1" stop-color="#974124"/>
     </linearGradient>
   </defs>
 

--- a/docs/assets/turing-cluster/logos/turing_cluster_logo_horizontal.svg
+++ b/docs/assets/turing-cluster/logos/turing_cluster_logo_horizontal.svg
@@ -9,15 +9,15 @@
       <stop offset="1" stop-color="#4E7C97"/>
     </linearGradient>
     <linearGradient id="cp" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#DB9560"/>
-      <stop offset="1" stop-color="#BE6C3A"/>
+      <stop offset="0" stop-color="#C4683F"/>
+      <stop offset="1" stop-color="#974124"/>
     </linearGradient>
   </defs>
 
   <!-- panel -->
   <rect x="1" y="1" width="798" height="238" rx="28" fill="url(#bg)" stroke="#2C4C61" stroke-width="1.5"/>
 
-  <!-- cluster icon: 2x2 nodes, control plane in copper -->
+  <!-- cluster icon: 2x2 nodes, control plane in terracotta -->
   <g transform="translate(80,44)">
     <g stroke="#4E7C97" fill="none" stroke-linecap="round">
       <g opacity="0.5" stroke-width="3">
@@ -47,8 +47,8 @@
 
   <!-- wordmark -->
   <g font-family="'Segoe UI','SF Pro Display',system-ui,-apple-system,'Helvetica Neue',Arial,sans-serif">
-    <text x="316" y="116" font-size="66" font-weight="800" letter-spacing="0.5" fill="#EAF2F7">TURING<tspan fill="#D2814E" dx="20">RK1</tspan></text>
-    <rect x="318" y="134" width="392" height="3" rx="1.5" fill="#D2814E" opacity="0.8"/>
+    <text x="316" y="116" font-size="66" font-weight="800" letter-spacing="0.5" fill="#EAF2F7">TURING<tspan fill="#C4683F" dx="20">RK1</tspan></text>
+    <rect x="318" y="134" width="392" height="3" rx="1.5" fill="#C4683F" opacity="0.8"/>
     <text x="320" y="168" font-size="19" font-weight="600" letter-spacing="4.4" fill="#7FA6BC">ANSIBLE · TERRAFORM · K3S · NPU</text>
   </g>
 </svg>


### PR DESCRIPTION
Per feedback, swaps the copper accent for a **deeper terracotta** across the banner and the square icon.

- Control-plane node gradient: `#DB9560 → #BE6C3A` (copper) → **`#C4683F → #974124`** (terracotta → brick).
- `RK1` wordmark + copper rule: `#D2814E` → **`#C4683F`**.

Still built to complement **PANTONE 17-4139 TCX Niagara** — just earthier and richer than the copper. Re-rendered with `rsvg-convert` to verify.