### PR TITLE
feat(brand): Ansible logo banner + provider/module links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Turing RK1 Ansible Cluster
 
-![Turing RK1 Ansible Cluster](docs/assets/turing-cluster/logos/turing_cluster_logo_horizontal.svg)
+![Turing RK1 Ansible Cluster](docs/assets/turing-cluster/logos/turing_cluster_logo_ansible_horizontal.svg)
 
 [![CI](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml/badge.svg)](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/ci.yml)
 [![Armbian Build](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/armbian-build.yml/badge.svg)](https://github.com/freed-dev-llc/turing-ansible-cluster/actions/workflows/armbian-build.yml)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Infrastructure-as-code for deploying K3s Kubernetes on Turing Pi RK1 hardware wi
 
 **[Architecture Documentation](docs/ARCHITECTURE.md)** - Visual diagrams for network topology, deployment pipeline, and component interactions.
 
+**Turing Pi Terraform / OpenTofu tooling** - self-published [provider](https://github.com/freed-dev-llc/terraform-provider-turingpi) and [modules](https://github.com/freed-dev-llc/terraform-turingpi-modules) (works with both Terraform and OpenTofu).
+
 ## Overview
 
 Deploy a 4-node K3s cluster on Turing Pi with:
@@ -249,7 +251,6 @@ GitHub Actions runs on every push and PR:
 
 ## Related Repositories
 
-- [terraform-provider-turingpi](https://github.com/freed-dev-llc/terraform-provider-turingpi) - Terraform BMC provider
 - [turing-rk1-cluster](https://github.com/freed-dev-llc/turing-rk1-cluster) - Original Talos Linux cluster
 
 ## License

--- a/docs/assets/turing-cluster/logos/turing_cluster_logo_ansible_horizontal.svg
+++ b/docs/assets/turing-cluster/logos/turing_cluster_logo_ansible_horizontal.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 260" width="800" height="260" role="img" aria-label="Turing RK1 Ansible — Control Node, Inventory, Managed Nodes">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1A2C39"/>
+      <stop offset="1" stop-color="#0F1C25"/>
+    </linearGradient>
+    <linearGradient id="node" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#6E9DBA"/>
+      <stop offset="1" stop-color="#4E7C97"/>
+    </linearGradient>
+    <linearGradient id="cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#C4683F"/>
+      <stop offset="1" stop-color="#974124"/>
+    </linearGradient>
+  </defs>
+
+  <!-- panel -->
+  <rect x="1" y="1" width="798" height="258" rx="28" fill="url(#bg)" stroke="#2C4C61" stroke-width="1.5"/>
+
+  <!-- cluster icon: 2x2 nodes, control plane in terracotta -->
+  <g transform="translate(80,58)">
+    <g stroke="#4E7C97" fill="none" stroke-linecap="round">
+      <g opacity="0.5" stroke-width="3">
+        <line x1="30" y1="30" x2="114" y2="30"/>
+        <line x1="30" y1="114" x2="114" y2="114"/>
+        <line x1="30" y1="30" x2="30" y2="114"/>
+        <line x1="114" y1="30" x2="114" y2="114"/>
+      </g>
+      <g opacity="0.26" stroke-width="2">
+        <line x1="30" y1="30" x2="114" y2="114"/>
+        <line x1="114" y1="30" x2="30" y2="114"/>
+      </g>
+    </g>
+    <g stroke="#EAF2F7" stroke-opacity="0.10" stroke-width="1">
+      <rect x="0"  y="0"  width="60" height="60" rx="13" fill="url(#cp)"/>
+      <rect x="84" y="0"  width="60" height="60" rx="13" fill="url(#node)"/>
+      <rect x="0"  y="84" width="60" height="60" rx="13" fill="url(#node)"/>
+      <rect x="84" y="84" width="60" height="60" rx="13" fill="url(#node)"/>
+    </g>
+    <g>
+      <circle cx="30"  cy="30"  r="6" fill="#FBEEE3" opacity="0.92"/>
+      <circle cx="114" cy="30"  r="6" fill="#EAF2F7" opacity="0.85"/>
+      <circle cx="30"  cy="114" r="6" fill="#EAF2F7" opacity="0.85"/>
+      <circle cx="114" cy="114" r="6" fill="#EAF2F7" opacity="0.85"/>
+    </g>
+  </g>
+
+  <!-- wordmark -->
+  <g font-family="'Segoe UI','SF Pro Display',system-ui,-apple-system,'Helvetica Neue',Arial,sans-serif">
+    <text x="306" y="110" font-size="62" font-weight="800" letter-spacing="0.5" fill="#EAF2F7">TURING<tspan fill="#C4683F" dx="20">RK1</tspan></text>
+    <rect x="308" y="128" width="372" height="3" rx="1.5" fill="#C4683F" opacity="0.8"/>
+    <text x="310" y="160" font-size="14.5" font-weight="600" letter-spacing="2.2" fill="#7FA6BC">CONTROL NODE · INVENTORY · MANAGED NODES</text>
+    <text x="310" y="200" font-size="23" font-weight="800" letter-spacing="11" fill="#C4683F">ANSIBLE</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Adds an Ansible-focused horizontal logo and uses it as the README top banner.

- New asset `docs/assets/turing-cluster/logos/turing_cluster_logo_ansible_horizontal.svg` — a sibling of the existing horizontal logo. Reuses the same palette, gradients, rounded panel, and 2×2 cluster glyph (terracotta control plane).
- Keeps the **TURING RK1** wordmark; swaps the subtitle to the Ansible model — `CONTROL NODE · INVENTORY · MANAGED NODES` — and adds a spaced **ANSIBLE** sub-brand line.
- Repoints the README top banner from `turing_cluster_logo_horizontal.svg` to the new asset.

## Trade-off

The header no longer shows the `ANSIBLE · TERRAFORM · K3S · NPU` full-stack subtitle; it now reads Ansible-first. The old logo file remains on disk (currently unreferenced).

## Preview

![banner](https://github.com/freed-dev-llc/turing-ansible-cluster/raw/feat/ansible-logo-banner/docs/assets/turing-cluster/logos/turing_cluster_logo_ansible_horizontal.svg)