### PR TITLE
fix(banner): frame the cluster glyph with inventory-style [ ] brackets

### DIFF
--- a/docs/assets/turing-cluster/logos/turing_cluster_logo_ansible_horizontal.svg
+++ b/docs/assets/turing-cluster/logos/turing_cluster_logo_ansible_horizontal.svg
@@ -19,6 +19,11 @@
 
   <!-- cluster icon: 2x2 nodes, control plane in terracotta -->
   <g transform="translate(80,58)">
+    <!-- inventory brackets framing the cluster -->
+    <g stroke="#C4683F" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.9">
+      <path d="M -8 -10 H -24 V 154 H -8"/>
+      <path d="M 152 -10 H 168 V 154 H 152"/>
+    </g>
     <g stroke="#4E7C97" fill="none" stroke-linecap="round">
       <g opacity="0.5" stroke-width="3">
         <line x1="30" y1="30" x2="114" y2="30"/>


### PR DESCRIPTION
Adds terracotta square brackets `[ ]` framing the 2×2 cluster glyph in the Ansible logo banner — reads like inventory/array notation, echoing the `INVENTORY` subtitle, and reuses the existing accent color.

Asset-only change to `turing_cluster_logo_ansible_horizontal.svg`.