### PR TITLE
feat(readme): brand-matched repo buttons for Turing Pi provider & modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Infrastructure-as-code for deploying K3s Kubernetes on Turing Pi RK1 hardware wi
 
 **[Architecture Documentation](docs/ARCHITECTURE.md)** - Visual diagrams for network topology, deployment pipeline, and component interactions.
 
-**Turing Pi Terraform / OpenTofu tooling** - self-published [provider](https://github.com/freed-dev-llc/terraform-provider-turingpi) and [modules](https://github.com/freed-dev-llc/terraform-turingpi-modules) (works with both Terraform and OpenTofu).
+**Turing Pi Terraform / OpenTofu tooling** (self-published, works with both Terraform and OpenTofu):
+
+[![Turing Pi Provider — freed-dev-llc/terraform-provider-turingpi](docs/assets/buttons/btn_terraform_provider_turingpi.svg)](https://github.com/freed-dev-llc/terraform-provider-turingpi)
+[![Turing Pi Modules — freed-dev-llc/terraform-turingpi-modules](docs/assets/buttons/btn_terraform_turingpi_modules.svg)](https://github.com/freed-dev-llc/terraform-turingpi-modules)
 
 ## Overview
 

--- a/docs/assets/buttons/btn_terraform_provider_turingpi.svg
+++ b/docs/assets/buttons/btn_terraform_provider_turingpi.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 372 72" width="372" height="72" role="img" aria-label="Turing Pi Terraform / OpenTofu provider — freed-dev-llc/terraform-provider-turingpi">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1A2C39"/><stop offset="1" stop-color="#0F1C25"/></linearGradient>
+    <linearGradient id="node" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#6E9DBA"/><stop offset="1" stop-color="#4E7C97"/></linearGradient>
+    <linearGradient id="cp" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#C4683F"/><stop offset="1" stop-color="#974124"/></linearGradient>
+  </defs>
+
+  <rect x="1" y="1" width="370" height="70" rx="16" fill="url(#bg)" stroke="#2C4C61" stroke-width="1.5"/>
+
+  <!-- glyph: 2x2 cluster framed by terracotta provider angle-brackets -->
+  <g transform="translate(23,13) scale(0.32)">
+    <g stroke="#4E7C97" fill="none" stroke-linecap="round">
+      <g opacity="0.5" stroke-width="3">
+        <line x1="30" y1="30" x2="114" y2="30"/><line x1="30" y1="114" x2="114" y2="114"/>
+        <line x1="30" y1="30" x2="30" y2="114"/><line x1="114" y1="30" x2="114" y2="114"/>
+      </g>
+      <g opacity="0.26" stroke-width="2">
+        <line x1="30" y1="30" x2="114" y2="114"/><line x1="114" y1="30" x2="30" y2="114"/>
+      </g>
+    </g>
+    <g fill="none" stroke="#C4683F" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+      <polyline points="-12,-6 -30,72 -12,150"/>
+      <polyline points="156,-6 174,72 156,150"/>
+    </g>
+    <g stroke="#EAF2F7" stroke-opacity="0.10" stroke-width="1">
+      <rect x="0" y="0" width="60" height="60" rx="13" fill="url(#cp)"/>
+      <rect x="84" y="0" width="60" height="60" rx="13" fill="url(#node)"/>
+      <rect x="0" y="84" width="60" height="60" rx="13" fill="url(#node)"/>
+      <rect x="84" y="84" width="60" height="60" rx="13" fill="url(#node)"/>
+    </g>
+    <g>
+      <circle cx="30" cy="30" r="6" fill="#FBEEE3" opacity="0.92"/>
+      <circle cx="114" cy="30" r="6" fill="#EAF2F7" opacity="0.85"/>
+      <circle cx="30" cy="114" r="6" fill="#EAF2F7" opacity="0.85"/>
+      <circle cx="114" cy="114" r="6" fill="#EAF2F7" opacity="0.85"/>
+    </g>
+  </g>
+
+  <!-- label -->
+  <g font-family="'Segoe UI','SF Pro Display',system-ui,-apple-system,'Helvetica Neue',Arial,sans-serif">
+    <text x="94" y="31" font-size="18" font-weight="700" letter-spacing="0.3" fill="#EAF2F7">Turing Pi <tspan fill="#C4683F">Provider</tspan></text>
+    <text x="94" y="52" font-size="10.5" font-weight="500" letter-spacing="0.2" fill="#7FA6BC" font-family="'SF Mono',ui-monospace,Menlo,Consolas,monospace">freed-dev-llc/terraform-provider-turingpi</text>
+  </g>
+</svg>

--- a/docs/assets/buttons/btn_terraform_turingpi_modules.svg
+++ b/docs/assets/buttons/btn_terraform_turingpi_modules.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 372 72" width="372" height="72" role="img" aria-label="Turing Pi Terraform modules — freed-dev-llc/terraform-turingpi-modules">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#1A2C39"/><stop offset="1" stop-color="#0F1C25"/></linearGradient>
+    <linearGradient id="node" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#6E9DBA"/><stop offset="1" stop-color="#4E7C97"/></linearGradient>
+    <linearGradient id="cp" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#C4683F"/><stop offset="1" stop-color="#974124"/></linearGradient>
+  </defs>
+
+  <rect x="1" y="1" width="370" height="70" rx="16" fill="url(#bg)" stroke="#2C4C61" stroke-width="1.5"/>
+
+  <!-- glyph: 2x2 cluster (control plane in terracotta) -->
+  <g transform="translate(23,13) scale(0.32)">
+    <g stroke="#4E7C97" fill="none" stroke-linecap="round">
+      <g opacity="0.5" stroke-width="3">
+        <line x1="30" y1="30" x2="114" y2="30"/><line x1="30" y1="114" x2="114" y2="114"/>
+        <line x1="30" y1="30" x2="30" y2="114"/><line x1="114" y1="30" x2="114" y2="114"/>
+      </g>
+      <g opacity="0.26" stroke-width="2">
+        <line x1="30" y1="30" x2="114" y2="114"/><line x1="114" y1="30" x2="30" y2="114"/>
+      </g>
+    </g>
+    <g stroke="#EAF2F7" stroke-opacity="0.10" stroke-width="1">
+      <rect x="0" y="0" width="60" height="60" rx="13" fill="url(#cp)"/>
+      <rect x="84" y="0" width="60" height="60" rx="13" fill="url(#node)"/>
+      <rect x="0" y="84" width="60" height="60" rx="13" fill="url(#node)"/>
+      <rect x="84" y="84" width="60" height="60" rx="13" fill="url(#node)"/>
+    </g>
+    <g>
+      <circle cx="30" cy="30" r="6" fill="#FBEEE3" opacity="0.92"/>
+      <circle cx="114" cy="30" r="6" fill="#EAF2F7" opacity="0.85"/>
+      <circle cx="30" cy="114" r="6" fill="#EAF2F7" opacity="0.85"/>
+      <circle cx="114" cy="114" r="6" fill="#EAF2F7" opacity="0.85"/>
+    </g>
+  </g>
+
+  <!-- label -->
+  <g font-family="'Segoe UI','SF Pro Display',system-ui,-apple-system,'Helvetica Neue',Arial,sans-serif">
+    <text x="94" y="31" font-size="18" font-weight="700" letter-spacing="0.3" fill="#EAF2F7">Turing Pi <tspan fill="#C4683F">Modules</tspan></text>
+    <text x="94" y="52" font-size="10.5" font-weight="500" letter-spacing="0.2" fill="#7FA6BC" font-family="'SF Mono',ui-monospace,Menlo,Consolas,monospace">freed-dev-llc/terraform-turingpi-modules</text>
+  </g>
+</svg>


### PR DESCRIPTION
Adds two compact, brand-matched repo buttons and wires them into the README's Turing Pi tooling section (replacing the plain text links).

- `docs/assets/buttons/btn_terraform_provider_turingpi.svg` → links to **freed-dev-llc/terraform-provider-turingpi**. Carries the terracotta angle-bracket "provider mark" framing the 2×2 cluster, mirroring `turingpi_logo_horizontal.svg`.
- `docs/assets/buttons/btn_terraform_turingpi_modules.svg` → links to **freed-dev-llc/terraform-turingpi-modules**. Uses the plain 2×2 cluster glyph from `turing_cluster_logo_horizontal.svg`.

Both reuse the shared brand palette (denim nodes + terracotta control plane on dark ink) and show their `owner/repo` handle.