### PR TITLE
fix(buttons): add curly-brace { } module mark to the modules button

### DIFF
--- a/docs/assets/buttons/btn_terraform_turingpi_modules.svg
+++ b/docs/assets/buttons/btn_terraform_turingpi_modules.svg
@@ -18,6 +18,11 @@
         <line x1="30" y1="30" x2="114" y2="114"/><line x1="114" y1="30" x2="30" y2="114"/>
       </g>
     </g>
+    <!-- MODULE MARK: curly braces framing the cluster - the HCL module block { } that wraps it -->
+    <g fill="none" stroke="#C4683F" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.85">
+      <path d="M -10 -8 Q -22 -8 -22 6 L -22 58 Q -22 72 -34 72 Q -22 72 -22 86 L -22 138 Q -22 152 -10 152"/>
+      <path d="M 154 -8 Q 166 -8 166 6 L 166 58 Q 166 72 178 72 Q 166 72 166 86 L 166 138 Q 166 152 154 152"/>
+    </g>
     <g stroke="#EAF2F7" stroke-opacity="0.10" stroke-width="1">
       <rect x="0" y="0" width="60" height="60" rx="13" fill="url(#cp)"/>
       <rect x="84" y="0" width="60" height="60" rx="13" fill="url(#node)"/>


### PR DESCRIPTION
The modules button glyph was missing its mark. Adds terracotta `{ }` curly braces framing the 2×2 cluster — mirroring the provider button's `< >` angle-bracket mark and echoing the HCL `module "x" { }` block.

Asset-only change to `btn_terraform_turingpi_modules.svg`. Both repo buttons now share a consistent mark language: `< >` = provider, `{ }` = modules.