### PR TITLE
docs: move overview tagline and fix non-browsable R2 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 [![Release](https://img.shields.io/github/v/release/freed-dev-llc/turing-ansible-cluster?sort=semver&color=blue)](https://github.com/freed-dev-llc/turing-ansible-cluster/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Infrastructure-as-code for deploying K3s Kubernetes on Turing Pi RK1 hardware with NPU support.
-
 **Turing Pi Terraform / OpenTofu tooling** (self-published, works with both Terraform and OpenTofu):
 
 [![Turing Pi Provider — freed-dev-llc/terraform-provider-turingpi](docs/assets/buttons/btn_terraform_provider_turingpi.svg)](https://github.com/freed-dev-llc/terraform-provider-turingpi)
 [![Turing Pi Modules — freed-dev-llc/terraform-turingpi-modules](docs/assets/buttons/btn_terraform_turingpi_modules.svg)](https://github.com/freed-dev-llc/terraform-turingpi-modules)
 
 ## Overview
+
+Infrastructure-as-code for deploying Kubernetes on Turing Pi RK1 hardware with NPU support.
 
 **[Architecture Documentation](docs/ARCHITECTURE.md)** - Visual diagrams for network topology, deployment pipeline, and component interactions.
 
@@ -202,7 +202,7 @@ For advanced options (custom packages, static IPs, SSH keys), see **[docs/ARMBIA
 
 ### Image Distribution
 
-Pre-built images are hosted on Cloudflare R2 at [armbian-builds.techki.to](https://armbian-builds.techki.to):
+Pre-built images are hosted on Cloudflare R2 (see [images.json](images.json) for the latest download URL and checksum):
 
 ```bash
 # Download latest image

--- a/docs/ARMBIAN-BUILD.md
+++ b/docs/ARMBIAN-BUILD.md
@@ -50,7 +50,7 @@ See [Image Preparation](#image-preparation) for full details on the prepare scri
 
 See [images.json](../images.json) for full metadata including download URLs and checksums.
 
-> **Note**: The automated build workflow checks daily for new Armbian versions and uploads images to Cloudflare R2 at [armbian-builds.techki.to](https://armbian-builds.techki.to).
+> **Note**: The automated build workflow checks daily for new Armbian versions and uploads images to Cloudflare R2.
 
 ## Automated Build Setup (Maintainers)
 
@@ -388,7 +388,7 @@ dmesg | grep -i rknpu
 
 If you don't need customization, download pre-built images:
 
-- **Pre-built (Recommended)**: [armbian-builds.techki.to](https://armbian-builds.techki.to/turing-rk1/armbian/26.08.0-trunk/Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz) - vendor kernel with NPU support
+- **Pre-built (Recommended)**: see [images.json](../images.json) for the latest download URL and checksum - vendor kernel with NPU support
 - **Turing Pi Ubuntu**: https://firmware.turingpi.com/turing-rk1/
 
 > **Note**: The pre-built images from armbian-builds.techki.to include the `vendor` branch kernel required for NPU support.
@@ -515,7 +515,7 @@ systemctl status iscsid
 
 ## Image Distribution
 
-Pre-built Armbian images are hosted on Cloudflare R2 at [armbian-builds.techki.to](https://armbian-builds.techki.to).
+Pre-built Armbian images are hosted on Cloudflare R2 (see [images.json](../images.json) for the latest download URL and checksum).
 
 ### Download Latest Image
 
@@ -524,7 +524,7 @@ Pre-built Armbian images are hosted on Cloudflare R2 at [armbian-builds.techki.t
 ./scripts/download-armbian-image.sh --latest
 
 # Or download directly
-wget https://armbian-builds.techki.to/turing-rk1/armbian/26.08.0-trunk/Armbian-unofficial_26.08.0-trunk_Turing-rk1_bookworm_vendor_6.1.115.img.xz
+wget $(jq -r '.latest.download_url' images.json)
 
 # Download and auto-decompress
 DECOMPRESS=true ./scripts/download-armbian-image.sh --latest


### PR DESCRIPTION
## Summary

- Move the infrastructure-as-code tagline from the badge header to directly under the **Overview** heading.
- Reword it: "K3s Kubernetes" → "Kubernetes".
- Replace non-browsable Cloudflare R2 bucket-host links and stale hard-coded image download URLs with references to the auto-updated `images.json` manifest, in both `README.md` and `docs/ARMBIAN-BUILD.md`.

## Why

The bare `armbian-builds.techki.to` host is intentionally non-browsable, so those links were dead. The hard-coded `26.08.0-trunk` download URLs go stale because the build workflow updates `images.json` (not the docs). Pointing at `images.json` keeps the references working and current automatically.

## Notes

Remaining `techki.to` mentions are intentional: maintainer `R2_PUBLIC_URL` config examples and one plain-text prose reference.