### PR TITLE
docs(brand): normalize horizontal logo height to 260

### DIFF
--- a/docs/assets/turing-cluster/logos/turing_cluster_logo_horizontal.svg
+++ b/docs/assets/turing-cluster/logos/turing_cluster_logo_horizontal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 240" width="800" height="240" role="img" aria-label="Turing RK1 Ansible Cluster">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 260" width="800" height="260" role="img" aria-label="Turing RK1 Ansible Cluster">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#1A2C39"/>
@@ -15,10 +15,10 @@
   </defs>
 
   <!-- panel -->
-  <rect x="1" y="1" width="798" height="238" rx="28" fill="url(#bg)" stroke="#2C4C61" stroke-width="1.5"/>
+  <rect x="1" y="1" width="798" height="258" rx="28" fill="url(#bg)" stroke="#2C4C61" stroke-width="1.5"/>
 
   <!-- cluster icon: 2x2 nodes, control plane in terracotta -->
-  <g transform="translate(80,44)">
+  <g transform="translate(80,54)">
     <g stroke="#4E7C97" fill="none" stroke-linecap="round">
       <g opacity="0.5" stroke-width="3">
         <line x1="30" y1="30" x2="114" y2="30"/>
@@ -46,7 +46,7 @@
   </g>
 
   <!-- wordmark -->
-  <g font-family="'Segoe UI','SF Pro Display',system-ui,-apple-system,'Helvetica Neue',Arial,sans-serif">
+  <g transform="translate(0,10)" font-family="'Segoe UI','SF Pro Display',system-ui,-apple-system,'Helvetica Neue',Arial,sans-serif">
     <text x="316" y="116" font-size="66" font-weight="800" letter-spacing="0.5" fill="#EAF2F7">TURING<tspan fill="#C4683F" dx="20">RK1</tspan></text>
     <rect x="318" y="134" width="392" height="3" rx="1.5" fill="#C4683F" opacity="0.8"/>
     <text x="320" y="168" font-size="19" font-weight="600" letter-spacing="4.4" fill="#7FA6BC">ANSIBLE · TERRAFORM · K3S · NPU</text>


### PR DESCRIPTION
Grow the base horizontal logo from `800×240` to `800×260` so every logo in the family renders at the same scale per the [README convention](https://github.com/freed-dev-llc/.github/blob/main/docs/turing-pi-readme-convention.md). (This base logo isn't currently shown in the README — the ansible variant is — but normalizing it keeps the asset family uniform.)

Non-distorting: viewBox/height and the background rect grow by 20px; the icon and wordmark groups shift down 10px to stay vertically centered. Artwork unchanged; XML validated.