### PR TITLE
ci: gate flaky molecule tests on ansible changes + retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,34 +94,3 @@ jobs:
         run: |
           terraform init -backend=false
           terraform validate
-
-  molecule:
-    name: Molecule Tests
-    runs-on: [self-hosted, linux]
-    strategy:
-      fail-fast: false
-      matrix:
-        role:
-          - base
-          - k3s_server
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: |
-          pip install ansible molecule molecule-docker docker
-
-      - name: Run Molecule tests
-        working-directory: ansible/roles/${{ matrix.role }}
-        run: |
-          molecule test
-        env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
-          ANSIBLE_ALLOW_BROKEN_CONDITIONALS: 'true'

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,0 +1,64 @@
+---
+name: Molecule
+
+# Heavyweight role tests (systemd/k3s-in-Docker) are flaky and slow, so they
+# only run when Ansible content actually changes. Docs/asset-only commits skip
+# them entirely. These are intentionally not required status checks; the
+# always-on "Ansible Lint" check in ci.yml is the merge gate.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ansible/**'
+      - '.github/workflows/molecule.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ansible/**'
+      - '.github/workflows/molecule.yml'
+
+jobs:
+  molecule:
+    name: Molecule Tests
+    runs-on: [self-hosted, linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        role:
+          - base
+          - k3s_server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install ansible molecule molecule-docker docker
+
+      # Container/systemd/k3s-in-Docker startup is racy (transient D-Bus resets
+      # and container exits), so retry the whole scenario before failing.
+      - name: Run Molecule tests
+        working-directory: ansible/roles/${{ matrix.role }}
+        run: |
+          attempts=3
+          for i in $(seq 1 "$attempts"); do
+            echo "::group::Molecule attempt $i of $attempts"
+            if molecule test; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "Attempt $i failed; cleaning up before retry" >&2
+            molecule destroy || true
+          done
+          echo "Molecule tests failed after $attempts attempts" >&2
+          exit 1
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          ANSIBLE_ALLOW_BROKEN_CONDITIONALS: 'true'


### PR DESCRIPTION
## Problem

`main` went red on commit #39 — a **docs-only** change (a single logo SVG) — because the heavyweight Molecule role tests ran and flaked:

- **base-test**: container exited mid-`verify` → `container ... is not running`
- **k3s-server-test**: `systemctl start k3s` reset the container's D-Bus → `Connection reset by peer`, `rc=1`

Both are transient systemd/k3s-in-Docker races, not logic bugs — the same code passed in #38 and failed in #39. Running them on docs/asset commits adds no signal and paints `main` red on infra flakiness alone.

## Changes

- **Split** the Molecule matrix out of `ci.yml` into a new `molecule.yml`, gated on `paths: ansible/**` so docs/asset-only commits no longer trigger it.
- **Kept** `lint` / `syntax-check` / `terraform-validate` always-on in `ci.yml`, so the required **Ansible Lint** merge gate still runs on every PR. (Path-filtering `ci.yml` as a whole would skip that required check and leave PRs stuck pending — hence the split.)
- **Wrapped** `molecule test` in a 3-attempt retry (with `molecule destroy` between attempts) to absorb the transient container/D-Bus failures on real Ansible changes.

## Notes

- Molecule was never a required status check, so this doesn't change merge gating.
- Deeper follow-up (out of scope): k3s-in-Docker is inherently unreliable for testing `systemctl start k3s`; a more robust design would install with `INSTALL_K3S_SKIP_START` and assert on artifacts rather than a live start.