### PR TITLE
test(k3s_server): install without starting k3s under Molecule

### DIFF
--- a/ansible/roles/k3s_server/defaults/main.yml
+++ b/ansible/roles/k3s_server/defaults/main.yml
@@ -20,3 +20,10 @@ cluster_name: "k3s-cluster"
 
 # Kubeconfig destination directory (defaults to parent of playbook directory)
 kubeconfig_dir: "{{ playbook_dir }}/.."
+
+# Skip starting the k3s service after install. Leave false in production so the
+# cluster comes up; set true for container-based testing (Molecule), where
+# systemd/D-Bus can't reliably start k3s. When true, the post-install steps
+# that need a running cluster (wait-for-ready, node-token, kubeconfig) are
+# skipped, but the binary, config, and (enabled) systemd unit are still created.
+k3s_server_skip_start: false

--- a/ansible/roles/k3s_server/handlers/main.yml
+++ b/ansible/roles/k3s_server/handlers/main.yml
@@ -4,6 +4,7 @@
     name: k3s
     state: restarted
     daemon_reload: true
+  when: not k3s_server_skip_start | bool
 
 - name: Update local kubeconfig server address
   delegate_to: localhost

--- a/ansible/roles/k3s_server/molecule/default/converge.yml
+++ b/ansible/roles/k3s_server/molecule/default/converge.yml
@@ -11,6 +11,11 @@
     k3s_version: "v1.31.4+k3s1"
     k3s_cluster_token: "molecule-test-token-not-for-production"
 
+    # systemd/k3s can't reliably start inside Docker, so install the binary,
+    # config, and (enabled) systemd unit without starting the service. Live
+    # cluster behaviour is validated on real hardware, not here.
+    k3s_server_skip_start: true
+
     # Network configuration (matches production defaults)
     pod_cidr: "10.244.0.0/16"
     service_cidr: "10.96.0.0/12"

--- a/ansible/roles/k3s_server/molecule/default/verify.yml
+++ b/ansible/roles/k3s_server/molecule/default/verify.yml
@@ -129,53 +129,23 @@
       register: k3s_service_status
       failed_when: false
 
-    - name: Display k3s service status
-      ansible.builtin.debug:
-        msg: "K3s service state: {{ k3s_service_status.status.ActiveState | default('unknown') }}"
-
-    # ==================== API Server Check ====================
-
-    - name: Wait for k3s API to be ready
-      ansible.builtin.command: k3s kubectl get nodes
-      register: k3s_nodes
-      until: k3s_nodes.rc == 0
-      retries: 30
-      delay: 10
-      changed_when: false
-      failed_when: false
-
-    - name: Verify k3s API is responding
+    - name: Verify k3s service is enabled
       ansible.builtin.assert:
         that:
-          - k3s_nodes.rc == 0
-        fail_msg: "K3s API not responding after 5 minutes"
-        success_msg: "K3s API is responding"
-      when: k3s_nodes is defined
+          - k3s_service_status.status.UnitFileState == "enabled"
+        fail_msg: "k3s.service should be enabled"
+        success_msg: "k3s.service is enabled"
 
-    - name: Display node status
+    - name: Display k3s service status
       ansible.builtin.debug:
-        msg: "{{ k3s_nodes.stdout_lines }}"
-      when: k3s_nodes.rc == 0
+        msg: >-
+          K3s service: {{ k3s_service_status.status.UnitFileState | default('unknown') }}
+          / {{ k3s_service_status.status.ActiveState | default('unknown') }}
 
-    # ==================== Token and Kubeconfig ====================
-
-    - name: Verify node token file exists
-      ansible.builtin.stat:
-        path: /var/lib/rancher/k3s/server/node-token
-      register: k3s_node_token
-      failed_when: not k3s_node_token.stat.exists
-
-    - name: Verify kubeconfig exists
-      ansible.builtin.stat:
-        path: /etc/rancher/k3s/k3s.yaml
-      register: k3s_kubeconfig
-      failed_when: not k3s_kubeconfig.stat.exists
-
-    - name: Verify kubeconfig has secure permissions
-      ansible.builtin.stat:
-        path: /etc/rancher/k3s/k3s.yaml
-      register: k3s_kubeconfig_perms
-      failed_when: k3s_kubeconfig_perms.stat.mode != "0600"
+    # Molecule installs k3s with INSTALL_K3S_SKIP_START (systemd/k3s can't
+    # reliably start inside Docker), so runtime artifacts — a live API,
+    # node-token, and kubeconfig — are not created here. Live cluster behaviour
+    # is validated on real hardware; this verify covers install + config.
 
     # ==================== Summary ====================
 
@@ -188,6 +158,5 @@
           - "Binary: {{ k3s_binary.stat.path }}"
           - "Version: {{ k3s_version_output.stdout | trim }}"
           - "Config: {{ k3s_config_file.stat.path }}"
-          - "Service: {{ k3s_service_status.status.ActiveState | default('unknown') }}"
-          - "API Ready: {{ 'Yes' if k3s_nodes.rc == 0 else 'No' }}"
+          - "Service: {{ k3s_service_status.status.UnitFileState | default('unknown') }}"
           - "=========================================="

--- a/ansible/roles/k3s_server/tasks/main.yml
+++ b/ansible/roles/k3s_server/tasks/main.yml
@@ -35,6 +35,7 @@
   environment:
     INSTALL_K3S_VERSION: "{{ k3s_version }}"
     K3S_TOKEN: "{{ k3s_cluster_token }}"
+    INSTALL_K3S_SKIP_START: "{{ 'true' if k3s_server_skip_start | bool else 'false' }}"
   ansible.builtin.command: /tmp/k3s-install.sh server
   args:
     creates: /usr/local/bin/k3s
@@ -46,6 +47,8 @@
   changed_when: false
   failed_when: k3s_version not in k3s_server_version_check.stdout
 
+# The remaining steps need a running cluster, so they are skipped when the
+# service was not started (k3s_server_skip_start, e.g. container testing).
 - name: Wait for k3s to be ready
   ansible.builtin.command: k3s kubectl get nodes
   register: k3s_server_ready
@@ -53,16 +56,19 @@
   retries: 30
   delay: 10
   changed_when: false
+  when: not k3s_server_skip_start | bool
 
 - name: Get k3s node token
   ansible.builtin.slurp:
     src: /var/lib/rancher/k3s/server/node-token
   register: k3s_server_node_token
+  when: not k3s_server_skip_start | bool
 
 - name: Set k3s token fact for agents
   ansible.builtin.set_fact:
     k3s_server_token: "{{ k3s_server_node_token.content | b64decode | trim }}"
     k3s_server_url: "https://{{ ansible_host }}:6443"
+  when: not k3s_server_skip_start | bool
 
 - name: Check if local kubeconfig exists
   delegate_to: localhost
@@ -71,6 +77,7 @@
     path: "{{ kubeconfig_dir }}/kubeconfig"
   register: k3s_server_local_kubeconfig
   run_once: true
+  when: not k3s_server_skip_start | bool
 
 - name: Fetch kubeconfig
   ansible.builtin.fetch:
@@ -78,5 +85,7 @@
     dest: "{{ kubeconfig_dir }}/kubeconfig"
     flat: true
   run_once: true
-  when: not k3s_server_local_kubeconfig.stat.exists
+  when:
+    - not k3s_server_skip_start | bool
+    - not k3s_server_local_kubeconfig.stat.exists
   notify: Update local kubeconfig server address


### PR DESCRIPTION
## Follow-up to #40

#40 added a retry wrapper to absorb Molecule flakiness. This removes the **root cause** for the `k3s_server` role: starting k3s via `systemctl start` is unreliable inside Docker — the D-Bus connection resets and the install step fails with `rc=1` (the exact failure that reddened `main` on #39).

## Approach

Install k3s with `INSTALL_K3S_SKIP_START` so the binary, config, and *enabled* systemd unit are created without bringing the service up, then assert on those artifacts instead of a live cluster.

- **`k3s_server_skip_start`** role var (default `false`) — production behaviour is unchanged: k3s still starts and all post-start steps run.
- Pass `INSTALL_K3S_SKIP_START` to the installer; gate the runtime steps (wait-for-ready, node-token, kubeconfig fetch) and the `Restart k3s` handler on the var so they only run when the service is actually started.
- Molecule `converge` sets it `true`; `verify` drops the live API / node-token / kubeconfig checks and instead asserts the service is installed and **enabled**.

## Coverage trade-off

Molecule now validates **install + config correctness** (binary, version, config.yaml contents, enabled unit) — not live cluster bring-up, which can't run reliably in a container and is validated on real hardware. The retry net from #40 stays for the `base` role's separate container-exit flakiness.

## Verification

- `yamllint` and `ansible-lint` (profile `production`) both pass clean locally.
- Molecule runs on the self-hosted ARM runner via this PR (touches `ansible/**`).