### PR TITLE
test(base): skip systemd/D-Bus operations under Molecule

### DIFF
--- a/ansible/roles/base/molecule/default/verify.yml
+++ b/ansible/roles/base/molecule/default/verify.yml
@@ -91,18 +91,9 @@
       loop: "{{ expected_sysctl | dict2items }}"
 
     # ==================== Hostname Configuration ====================
-
-    - name: Get current hostname
-      ansible.builtin.command: hostname
-      register: current_hostname
-      changed_when: false
-
-    - name: Verify hostname is set correctly
-      ansible.builtin.assert:
-        that:
-          - current_hostname.stdout == inventory_hostname
-        fail_msg: "Hostname mismatch: expected {{ inventory_hostname }}, got {{ current_hostname.stdout }}"
-        success_msg: "Hostname is set correctly to {{ inventory_hostname }}"
+    # Note: the live hostname is applied via hostnamectl (D-Bus) on real
+    # hardware only; in containers we assert the /etc/hostname file the role
+    # writes, which is the durable configuration.
 
     - name: Verify /etc/hostname content
       ansible.builtin.slurp:
@@ -132,20 +123,8 @@
         success_msg: "/etc/hosts exists"
 
     # ==================== Timezone Configuration ====================
-
-    - name: Get current timezone
-      ansible.builtin.command: timedatectl show --property=Timezone --value
-      register: current_timezone
-      changed_when: false
-      failed_when: false
-
-    - name: Verify timezone is set (if timedatectl available)
-      ansible.builtin.assert:
-        that:
-          - current_timezone.stdout == "UTC"
-        fail_msg: "Timezone mismatch: expected UTC, got {{ current_timezone.stdout }}"
-        success_msg: "Timezone is correctly set to UTC"
-      when: current_timezone.rc == 0
+    # Note: timezone is applied via timedatectl (D-Bus) on real hardware only,
+    # so it is not asserted in container tests (skipped under molecule_test).
 
     # ==================== iSCSI Configuration ====================
 
@@ -168,15 +147,8 @@
             fail_msg: "iscsid service file not found"
             success_msg: "iscsid service file exists"
 
-        - name: Get iscsid service status
-          ansible.builtin.systemd:
-            name: iscsid
-          register: iscsid_status
-          failed_when: false
-
-        - name: Display iscsid service status
-          ansible.builtin.debug:
-            msg: "iscsid service state: {{ iscsid_status.status.ActiveState | default('unknown') }}"
+        # Live service state (iscsid running) is checked on real hardware only;
+        # starting it via systemd/D-Bus is unreliable in containers.
 
         - name: Verify iSCSI initiator name file exists
           ansible.builtin.stat:
@@ -211,7 +183,7 @@
         packages_ok: true
         kernel_modules_ok: "{{ kernel_modules_config.stat.exists }}"
         sysctl_ok: "{{ sysctl_config.stat.exists }}"
-        hostname_ok: "{{ current_hostname.stdout == inventory_hostname }}"
+        hostname_ok: "{{ (etc_hostname.content | b64decode | trim) == inventory_hostname }}"
         hosts_ok: "{{ etc_hosts.stat.exists }}"
         iscsi_ok: "{{ iscsi_initiator.stat.exists | default(false) }}"
 

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -46,6 +46,9 @@
 - name: Set hostname
   ansible.builtin.hostname:
     name: "{{ inventory_hostname }}"
+  # hostnamectl talks to systemd over D-Bus, which is unreliable in containers;
+  # the /etc/hostname file written below is what tests assert against.
+  when: not (molecule_test | default(false))
 
 - name: Update /etc/hostname file
   ansible.builtin.copy:
@@ -63,16 +66,22 @@
 - name: Set timezone
   community.general.timezone:
     name: "{{ base_timezone }}"
+  # timedatectl uses D-Bus, unreliable in containers; set on real hardware only.
+  when: not (molecule_test | default(false))
 
 # iSCSI configuration for Longhorn
 - name: Configure iSCSI for Longhorn
   when: "'open-iscsi' in base_packages"
   block:
+    # Starting iscsid pulls in systemd/D-Bus, which can't reliably bring a
+    # service up inside a container, so skip the live start under Molecule and
+    # validate it on real hardware. The initiator-name file below is still set.
     - name: Ensure iscsid service is enabled and started
       ansible.builtin.systemd:
         name: iscsid
         state: started
         enabled: true
+      when: not (molecule_test | default(false))
 
     - name: Ensure iscsi socket is enabled
       ansible.builtin.systemd:
@@ -80,6 +89,7 @@
         state: started
         enabled: true
       failed_when: false
+      when: not (molecule_test | default(false))
 
     - name: Verify iSCSI initiator name exists
       ansible.builtin.stat:


### PR DESCRIPTION
## Follow-up to #40 / #41

Same treatment as #41 (k3s), now for the `base` role. The base container test was the remaining flaky job — the container exited mid-`verify`, last seen at a `timedatectl show` call. Root cause is identical: systemd/D-Bus operations don't run reliably inside Docker and can destabilize the container's PID 1.

## Approach

Gate the active systemd/D-Bus operations on the **existing** `molecule_test` flag (default `false`, so production behaviour is unchanged) and assert on durable config files instead of live system state.

**`tasks/main.yml`** (skipped under `molecule_test`):
- `Set hostname` — hostnamectl/D-Bus
- `Set timezone` — timedatectl/D-Bus
- `Ensure iscsid service is enabled and started` (+ socket) — systemctl start

The `/etc/hostname` file and the iSCSI initiator-name file are still written, so config coverage is unchanged.

**`verify.yml`** — drop the live D-Bus checks (`hostname` cmd, `timedatectl`, iscsid `systemd` status); assert `/etc/hostname` content and the iscsid service-file + initiator-file instead.

## Coverage trade-off

Container test now validates **config correctness** (packages, kernel-module + sysctl config files, `/etc/hostname`, iscsid unit + initiator files). Live hostname/timezone application and a running iscsid are validated on real hardware — they can't run reliably in a container. This mirrors #41 and should make `base` deterministic; the #40 retry net stays as a backstop.

## Verification

`yamllint` and `ansible-lint` (profile `production`) pass clean locally. Molecule runs on the self-hosted ARM runner via this PR (touches `ansible/**`).